### PR TITLE
Make navigation asset paths relative

### DIFF
--- a/article.html
+++ b/article.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
     <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700" rel="stylesheet" type="text/css" />
 <!-- Bootstrap/Genel -->
-	<link href="/css/styles.css" rel="stylesheet" />
+        <link href="css/styles.css" rel="stylesheet" />
     <style>
         .lang-switch {
             display: inline-block;
@@ -45,7 +45,7 @@
                             <li><a class="dropdown-item custom-dropdown-item" href="/solutions/#sectionC">C</a></li>
                    </ul>
                 </li> -->
-                    <li class="nav-item"><a class="nav-link" href="/">Blog</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html">Blog</a></li>
                   <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="aboutDropdown" data-bs-toggle="dropdown" aria-expanded="false">About Us</a>
                     <ul class="dropdown-menu custom-dropdown-menu" aria-labelledby="aboutDropdown">
@@ -169,7 +169,7 @@
 
 			<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 			<script src="https://kit.fontawesome.com/yourfontawesomekit.js" crossorigin="anonymous"></script>
-			<script src="/js/scripts.js"></script>
+                        <script src="js/scripts.js"></script>
 	<script>
 document.addEventListener('DOMContentLoaded', function () {
   // 1. URL'den slug/id oku (?slug=2025-07-14-sera-gazlari gibi)
@@ -233,7 +233,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const slug = params.get('slug');
       const trSwitch = document.querySelector('.lang-switch.tr-switch');
       if (trSwitch && slug) {
-        trSwitch.onclick = () => window.location.href = `/tr/article.html?slug=${slug}`;
+        trSwitch.onclick = () => window.location.href = `tr/article.html?slug=${slug}`;
       }
     });
     </script>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
     <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700" rel="stylesheet" type="text/css" />
 <!-- Bootstrap/Genel -->
-	<link href="/css/styles.css" rel="stylesheet" />
+        <link href="css/styles.css" rel="stylesheet" />
     <style>
         .lang-switch {
             display: inline-block;
@@ -45,7 +45,7 @@
                             <li><a class="dropdown-item custom-dropdown-item" href="/solutions/#sectionC">C</a></li>
                    </ul>
                 </li> -->
-                    <li class="nav-item"><a class="nav-link" href="/">Blog</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html">Blog</a></li>
                   <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="aboutDropdown" data-bs-toggle="dropdown" aria-expanded="false">About Us</a>
                     <ul class="dropdown-menu custom-dropdown-menu" aria-labelledby="aboutDropdown">
@@ -57,8 +57,8 @@
                     </ul>
                   </li>
                   <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">Contact</a></li>
-                      <div class="lang-switch" onclick="window.location.href='../tr/'">TR</div>
-                      <div class="lang-switch" onclick="window.location.href='/'">EN</div>
+                      <div class="lang-switch" onclick="window.location.href='tr/index.html'">TR</div>
+                      <div class="lang-switch" onclick="window.location.href='index.html'">EN</div>
                   </li>
                 </ul>
             </div>
@@ -158,7 +158,7 @@
 <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://kit.fontawesome.com/yourfontawesomekit.js" crossorigin="anonymous"></script>
-    <script src="/js/scripts.js"></script>
+    <script src="js/scripts.js"></script>
 
 </body>
 </html>

--- a/tr/article.html
+++ b/tr/article.html
@@ -45,7 +45,7 @@
                             <li><a class="dropdown-item custom-dropdown-item" href="/solutions/#sectionC">C</a></li>
                    </ul>
                 </li> -->
-                    <li class="nav-item"><a class="nav-link" href="/">Blog</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html">Blog</a></li>
                   <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="aboutDropdown" data-bs-toggle="dropdown" aria-expanded="false">Hakkımızda</a>
                     <ul class="dropdown-menu custom-dropdown-menu" aria-labelledby="aboutDropdown">

--- a/tr/index.html
+++ b/tr/index.html
@@ -45,7 +45,7 @@
                             <li><a class="dropdown-item custom-dropdown-item" href="/solutions/#sectionC">C</a></li>
                    </ul>
                 </li> -->
-                    <li class="nav-item"><a class="nav-link" href="/">Blog</a></li>
+                    <li class="nav-item"><a class="nav-link" href="index.html">Blog</a></li>
                   <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="aboutDropdown" data-bs-toggle="dropdown" aria-expanded="false">Hakkımızda</a>
                     <ul class="dropdown-menu custom-dropdown-menu" aria-labelledby="aboutDropdown">
@@ -57,8 +57,8 @@
                     </ul>
                   </li>
                   <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">İletişim</a></li>
-                      <div class="lang-switch" onclick="window.location.href='/'">TR</div>
-                      <div class="lang-switch" onclick="window.location.href='../'">EN</div>
+                      <div class="lang-switch" onclick="window.location.href='index.html'">TR</div>
+                      <div class="lang-switch" onclick="window.location.href='../index.html'">EN</div>
                   </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- update the English blog index and article pages to load local CSS/JS with relative paths
- switch English navigation links and language toggles to relative URLs
- align the Turkish navigation links and language toggles with relative paths as well

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68c98bb4cf98832e96008048bff440db