### PR TITLE
Move language switch controls into nav list items

### DIFF
--- a/article.html
+++ b/article.html
@@ -57,9 +57,8 @@
                     </ul>
                   </li>
                   <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">Contact</a></li>
-                      <div class="lang-switch tr-switch">TR</div>
-                      <div class="lang-switch en-switch">EN</div>
-                  </li>
+                  <li class="nav-item lang-switch tr-switch">TR</li>
+                  <li class="nav-item lang-switch en-switch">EN</li>
                 </ul>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -57,9 +57,8 @@
                     </ul>
                   </li>
                   <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">Contact</a></li>
-                      <div class="lang-switch" onclick="window.location.href='../tr/'">TR</div>
-                      <div class="lang-switch" onclick="window.location.href='/'">EN</div>
-                  </li>
+                  <li class="nav-item lang-switch" onclick="window.location.href='../tr/'">TR</li>
+                  <li class="nav-item lang-switch" onclick="window.location.href='/'">EN</li>
                 </ul>
             </div>
         </div>

--- a/tr/article.html
+++ b/tr/article.html
@@ -57,9 +57,8 @@
                     </ul>
                   </li>
                   <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">Contact</a></li>
-                      <div class="lang-switch tr-switch">TR</div>
-                      <div class="lang-switch en-switch">EN</div>
-                  </li>
+                  <li class="nav-item lang-switch tr-switch">TR</li>
+                  <li class="nav-item lang-switch en-switch">EN</li>
                 </ul>
             </div>
         </div>

--- a/tr/index.html
+++ b/tr/index.html
@@ -57,9 +57,8 @@
                     </ul>
                   </li>
                   <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">İletişim</a></li>
-                      <div class="lang-switch" onclick="window.location.href='/'">TR</div>
-                      <div class="lang-switch" onclick="window.location.href='../'">EN</div>
-                  </li>
+                  <li class="nav-item lang-switch" onclick="window.location.href='/'">TR</li>
+                  <li class="nav-item lang-switch" onclick="window.location.href='../'">EN</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- move the language toggle controls in each navbar into `<li>` elements so they are part of the list structure
- remove the stray closing `</li>` tags that followed the language toggle markup

## Testing
- not run (static HTML changes)


------
https://chatgpt.com/codex/tasks/task_e_68c98bb5107c832eb9c564064ff17b5f