### PR TITLE
Ensure blog card image maintains 16:9 crop

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1950,7 +1950,8 @@ h1, h2, h3, h4, h5 {
 /* KART GÖRSELİ */
 .blog-card-img {
   width: 100%;
-  aspect-ratio: 16/9 !important;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
   background: #dbeafe;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- update the blog card image container to rely on an explicit 16:9 aspect ratio while preserving flex behavior
- apply cover sizing to the container so featured images consistently fill the frame

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c98bee613c832ead60daf399317a7e