### PR TITLE
Add article masthead styles and remove inline CSS

### DIFF
--- a/article.html
+++ b/article.html
@@ -65,8 +65,8 @@
         </div>
     </nav>
 <!-- Masthead -->
-<!-- 
-	<header class="masthead" style="height:60vh; min-height:350px; display:flex; align-items:center;">
+<!--
+        <header class="masthead">
     <div class="container">
         <div class="masthead-heading">Rise<br>for a</div>
         <div class="masthead-subheading-script">Cleaner</div>
@@ -77,7 +77,7 @@
     </div>
 </header>
 -->
-	<header class="masthead article-masthead" id="article-masthead" style="height:60vh; min-height:350px; display:flex; align-items:end; background-size:cover; background-position:center; background-repeat:no-repeat;">
+        <header class="masthead article-masthead" id="article-masthead">
     <div class="container">
         <div class="article-masthead-info">
             <span id="article-category-head" class="badge bg-success me-2"></span>
@@ -92,7 +92,7 @@
   <div class="row justify-content-center">
     <div class="col-lg-10 col-xl-8">
       <article class="blog-single border-0 shadow-none">
-        <img id="article-image" src="" alt="" class="img-fluid rounded mb-3" style="display:none; max-height:320px; object-fit:cover;">
+        <img id="article-image" src="" alt="" class="img-fluid rounded mb-3 article-image">
         <div class="mb-2">
           <span id="article-category" class="badge bg-success me-2"></span>
           <span id="article-date" class="text-muted small"></span>
@@ -101,7 +101,7 @@
         <div id="article-summary" class="lead text-muted mb-3"></div>
         <div id="article-content" class="blog-content"></div>
       </article>
-      <div id="article-notfound" class="alert alert-warning mt-4" style="display:none;">Article not found.</div>
+      <div id="article-notfound" class="alert alert-warning mt-4 article-notfound">Article not found.</div>
     </div>
   </div>
 </main>
@@ -149,13 +149,13 @@
             </div>
             <div class="col-lg-4 my-3 my-lg-0 text-center">
                 <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="X">
-                    <img src="assets/img/logos/icons8-x-500.svg" alt="X" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                    <img src="assets/img/logos/icons8-x-500.svg" alt="X" class="footer-social-icon" />
                 </a>
                 <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="Instagram">
-                    <img src="assets/img/logos/icons8-instagram-500.svg" alt="Instagram" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                    <img src="assets/img/logos/icons8-instagram-500.svg" alt="Instagram" class="footer-social-icon" />
                 </a>
                 <a class="btn btn-dark btn-social mx-2" href="https://www.linkedin.com/company/greenairiva/" aria-label="LinkedIn">
-                    <img src="assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                    <img src="assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" class="footer-social-icon" />
                 </a>
             </div>
             <div class="col-lg-4 text-lg-end text-center">

--- a/css/styles.css
+++ b/css/styles.css
@@ -1763,6 +1763,96 @@ header.masthead .container {
 /* ==== Masthead Butonunu Web ve Mobilde Sağa Yasla ve Optimize Et Sonu ==== */
  /* Masthead*/
 
+/* Article Masthead */
+header.masthead.article-masthead {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  height: 60vh;
+  min-height: 350px;
+  padding: 6rem 0 3rem;
+  color: #fff;
+  background-color: #212529;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  overflow: hidden;
+}
+
+header.masthead.article-masthead::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(18, 20, 24, 0.2) 0%, rgba(18, 20, 24, 0.75) 100%);
+  pointer-events: none;
+}
+
+.article-masthead .container {
+  position: relative;
+  z-index: 1;
+}
+
+.article-masthead-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.article-masthead-title {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 700;
+  margin-bottom: 0;
+}
+
+.article-masthead .badge {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.article-masthead .text-light,
+.article-masthead .article-masthead-title {
+  color: #fff;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.article-image {
+  display: none;
+  max-height: 320px;
+  object-fit: cover;
+}
+
+.article-notfound {
+  display: none;
+}
+
+.footer-social-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  filter: invert(1);
+}
+
+@media (max-width: 991.98px) {
+  header.masthead.article-masthead {
+    height: auto;
+    min-height: 320px;
+    padding-top: 7rem;
+    padding-bottom: 2.5rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  header.masthead.article-masthead {
+    padding-top: 6.5rem;
+    padding-bottom: 2rem;
+  }
+
+  .article-masthead-title {
+    font-size: clamp(2rem, 9vw, 2.8rem);
+  }
+}
+
   /* 06.3 Timeline */
 .timeline {
   position: relative;

--- a/tr/article.html
+++ b/tr/article.html
@@ -65,8 +65,8 @@
         </div>
     </nav>
 <!-- Masthead -->
-<!-- 
-	<header class="masthead" style="height:60vh; min-height:350px; display:flex; align-items:center;">
+<!--
+        <header class="masthead">
     <div class="container">
         <div class="masthead-heading">Rise<br>for a</div>
         <div class="masthead-subheading-script">Cleaner</div>
@@ -77,7 +77,7 @@
     </div>
 </header>
 -->
-	<header class="masthead article-masthead" id="article-masthead" style="height:60vh; min-height:350px; display:flex; align-items:end; background-size:cover; background-position:center; background-repeat:no-repeat;">
+        <header class="masthead article-masthead" id="article-masthead">
     <div class="container">
         <div class="article-masthead-info">
             <span id="article-category-head" class="badge bg-success me-2"></span>
@@ -92,7 +92,7 @@
   <div class="row justify-content-center">
     <div class="col-lg-10 col-xl-8">
       <article class="blog-single border-0 shadow-none">
-        <img id="article-image" src="" alt="" class="img-fluid rounded mb-3" style="display:none; max-height:320px; object-fit:cover;">
+        <img id="article-image" src="" alt="" class="img-fluid rounded mb-3 article-image">
         <div class="mb-2">
           <span id="article-category" class="badge bg-success me-2"></span>
           <span id="article-date" class="text-muted small"></span>
@@ -101,7 +101,7 @@
         <div id="article-summary" class="lead text-muted mb-3"></div>
         <div id="article-content" class="blog-content"></div>
       </article>
-      <div id="article-notfound" class="alert alert-warning mt-4" style="display:none;">Article not found.</div>
+      <div id="article-notfound" class="alert alert-warning mt-4 article-notfound">Article not found.</div>
     </div>
   </div>
 </main>
@@ -149,13 +149,13 @@
             </div>
             <div class="col-lg-4 my-3 my-lg-0 text-center">
                 <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="X">
-                    <img src="../assets/img/logos/icons8-x-500.svg" alt="X" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                    <img src="../assets/img/logos/icons8-x-500.svg" alt="X" class="footer-social-icon" />
                 </a>
                 <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="Instagram">
-                    <img src="../assets/img/logos/icons8-instagram-500.svg" alt="Instagram" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                    <img src="../assets/img/logos/icons8-instagram-500.svg" alt="Instagram" class="footer-social-icon" />
                 </a>
                 <a class="btn btn-dark btn-social mx-2" href="https://www.linkedin.com/company/greenairiva/" aria-label="LinkedIn">
-                    <img src="../assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                    <img src="../assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" class="footer-social-icon" />
                 </a>
             </div>
             <div class="col-lg-4 text-lg-end text-center">


### PR DESCRIPTION
## Summary
- create a dedicated `article-masthead` style block with height, overlay, typography, and responsive tweaks
- replace inline styles in the English and Turkish article pages with semantic utility classes for the hero, article image, fallback alert, and footer icons

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c98bfcda54832ea4b0069bd65f3ce6