### PR TITLE
GreenAiriva blog board (dark grid + meta footer + pager)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2168,3 +2168,58 @@ h1, h2, h3, h4, h5 {
 /* =========================================================
    07. Print
    ========================================================= */
+/* === GreenAiriva Blog Board (Dark) === */
+.ga-board { background:#0f1115; padding:2.5rem 0 3.5rem; }
+.ga-title { color:#fff; font-size:clamp(1.4rem,2.5vw,1.8rem); font-weight:800; margin:0 0 1rem; }
+.ga-toolbar { display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:1rem; }
+.ga-tags { display:flex; gap:.5rem; overflow:auto; padding-bottom:.25rem; scrollbar-width:none; }
+.ga-tags::-webkit-scrollbar{ display:none; }
+
+.ga-pill {
+  background:#151923; color:#cbd5e1; border:1px solid #1f2430;
+  padding:.45rem .85rem; border-radius:1rem; font-weight:600; white-space:nowrap;
+}
+.ga-pill:hover { background:#1a2030; color:#e5e7eb; }
+.ga-pill.active { background:#2a3347; color:#fff; border-color:#2f3a51; }
+
+.ga-search { background:#0f131c; color:#e5e7eb; border:1px solid #1f2430; padding:.55rem .9rem; border-radius:.6rem; min-width:220px; }
+.ga-search::placeholder{ color:#93a1b5; }
+
+.ga-grid { display:grid; grid-template-columns:repeat(1,minmax(0,1fr)); gap:1rem; }
+@media (min-width:768px){ .ga-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
+@media (min-width:1200px){ .ga-grid{ grid-template-columns:repeat(3,minmax(0,1fr)); } }
+.ga-empty{ color:#9fb0c9; text-align:center; padding:2.4rem 0; font-size:.95rem; }
+
+.ga-card {
+  background:#11151e; border:1px solid #1a2030; border-radius:14px;
+  box-shadow:0 6px 20px rgba(0,0,0,.25); overflow:hidden; display:flex; flex-direction:column;
+  transition:transform .18s ease, box-shadow .18s ease, border-color .18s;
+}
+.ga-card:hover{ transform:translateY(-2px); box-shadow:0 16px 40px rgba(0,0,0,.35); border-color:#273149; }
+
+.ga-thumb{ display:block; aspect-ratio:16/9; background:#0b0d12; }
+.ga-thumb img{ width:100%; height:100%; object-fit:cover; display:block; }
+
+.ga-body{ padding:.9rem .95rem .25rem; }
+.ga-h3{ margin:0 0 .35rem; font-size:1rem; line-height:1.35; }
+.ga-h3 a{ color:#eef2ff; text-decoration:none; }
+.ga-h3 a:hover{ text-decoration:underline; }
+.ga-excerpt{ color:#98a6be; font-size:.92rem; line-height:1.55; margin:0; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+
+.ga-meta{
+  display:flex; align-items:center; justify-content:space-between;
+  padding:.6rem .8rem .8rem; gap:.5rem; border-top:1px solid #1a2030; color:#9fb0c9;
+}
+.ga-meta-left{ display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; }
+.ga-badge{ background:#172033; color:#cbd5e1; border:1px solid #24314a; font-size:.75rem; padding:.15rem .5rem; border-radius:.5rem;}
+.ga-dot{ width:4px; height:4px; background:#3b4457; border-radius:999px; display:inline-block; margin:0 .15rem; }
+.ga-sep{ opacity:.6; }
+.ga-read{ font-size:.82rem; }
+
+.ga-meta-right{ display:flex; align-items:center; gap:.55rem; }
+.ga-stat{ display:inline-flex; align-items:center; gap:.35rem; font-size:.82rem; color:#9fb0c9; }
+.ga-stat svg{ width:16px; height:16px; opacity:.85; }
+
+.ga-pager{ display:flex; justify-content:center; gap:.4rem; margin-top:1rem; }
+.ga-pager .pg{ background:#151923; color:#cfd8ea; border:1px solid #222a3a; padding:.5rem .75rem; border-radius:.5rem; }
+.ga-pager .pg.active, .ga-pager .pg:hover{ background:#2a3347; color:#fff; border-color:#2f3a51; }

--- a/index.html
+++ b/index.html
@@ -75,26 +75,20 @@
     </div>
 </header>
 
-    <!-- Blog Main -->
-    <main class="container my-5">
-        <div class="row align-items-center mb-4">
-            <div class="col">
-                <h2 class="mb-0">Latest Blog Posts</h2>
-            </div>
-            <div class="col-auto">
-                <select class="form-select" id="postFilter" style="min-width:180px;">
-                    <option value="">All Categories</option>
-                </select>
-            </div>
+    <!-- GreenAiriva Blog Board -->
+    <section id="ga-board" class="ga-board">
+      <div class="container">
+        <h2 class="ga-title">Latest Insights</h2>
+        <div class="ga-toolbar">
+          <div class="ga-tags" id="gaTagBar"></div>
+          <div class="ga-actions">
+            <input id="gaSearch" class="ga-search" placeholder="Search posts…" />
+          </div>
         </div>
-        <div id="postList"></div>
-        <div class="text-center my-4">
-            <button class="btn btn-success btn-lg px-5 py-2" id="loadMoreBtn" style="display:none;">
-                <span class="fw-semibold">Load More</span>
-                <i class="fas fa-angle-down ms-2"></i>
-            </button>
-        </div>
-    </main>
+        <div id="gaGrid" class="ga-grid"></div>
+        <div class="ga-pager" id="gaPager"></div>
+      </div>
+    </section>
 
    <!-- Contact-->
 <section class="page-section" id="contact">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -222,3 +222,166 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
+function gaBlogBoardInit(){
+  const isIndex = /(^\/(index\.html)?$)|(^\/tr\/(index\.html)?$)/.test(location.pathname);
+  if(!isIndex) return;
+
+  const lang = location.pathname.startsWith('/tr') ? 'tr' : 'en';
+  const jsonURL = lang==='tr' ? '/tr/posts.json' : '/posts.json';
+  const state = { q:'', tag:null, page:1, per:9, rows:[] };
+
+  const $grid = document.getElementById('gaGrid');
+  const $pager = document.getElementById('gaPager');
+  const $tagBar = document.getElementById('gaTagBar');
+  const $search = document.getElementById('gaSearch');
+
+  if(!$grid || !$pager || !$tagBar) return;
+
+  const GA_TAGS_FALLBACK = [
+    'greenairiva','urban-air','air-quality','methane','nitrous-oxide',
+    'device','prototype','adsorbent','solar','field-test','policy','r-and-d'
+  ];
+
+  const icons = {
+    eye:`<svg viewBox="0 0 24 24" fill="none"><path d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z" stroke="currentColor" stroke-width="1.6"/><circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.6"/></svg>`,
+    cmt:`<svg viewBox="0 0 24 24" fill="none"><path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4v8Z" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/></svg>`,
+    like:`<svg viewBox="0 0 24 24" fill="none"><path d="M12 21s-7-4.35-9-8c-2-3.65 1-8 5-8 3 0 4 2 4 2s1-2 4-2c4 0 7 4.35 5 8-2 3.65-9 8-9 8Z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>`
+  };
+
+  const brandifyTag = (value) => {
+    const base = String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    return base ? `greenairiva-${base}` : 'greenairiva';
+  };
+
+  const normaliseRows = (arr) => arr.map((item) => {
+    const baseTags = Array.isArray(item.tags) ? item.tags :
+      Array.isArray(item.category) ? item.category :
+      item.category ? [item.category] : [];
+    const slugDerived = (item.slug || '')
+      .split(/[^a-z0-9]+/i)
+      .filter(Boolean)
+      .slice(0, 3);
+    const tagsSource = baseTags.length ? baseTags : slugDerived;
+    const tags = tagsSource.length ? tagsSource.map(brandifyTag) : ['greenairiva'];
+    const uniqueTags = [...new Set(tags)];
+    const minutesCandidate = parseInt(item.readingMinutes || item.reading_minutes || item.reading || item.minutes, 10);
+    return {
+      ...item,
+      lang: item.lang || lang,
+      cover: item.cover || item.image || item.thumbnail || '',
+      excerpt: item.excerpt || item.summary || item.description || '',
+      tags: uniqueTags,
+      readingMinutes: Number.isFinite(minutesCandidate) && minutesCandidate > 0 ? minutesCandidate : 5
+    };
+  });
+
+  const applyData = (rows = []) => {
+    state.rows = normaliseRows(rows).filter((entry) => entry.lang === lang);
+    buildTags();
+    render();
+  };
+
+  fetch(jsonURL)
+    .then((r) => r.json())
+    .then(applyData)
+    .catch(() => {
+      state.rows = [];
+      buildTags();
+      render(true);
+    });
+
+  function buildTags(){
+    const fromData = [...new Set(state.rows.flatMap((p) => p.tags || []))];
+    const tags = (fromData.length ? fromData : GA_TAGS_FALLBACK).slice(0, 12);
+    $tagBar.innerHTML = tags.map((t) => `<button class="ga-pill${state.tag===t ? ' active' : ''}" data-tag="${t}">#${t}</button>`).join('');
+  }
+
+  function render(isError){
+    let rows = state.rows.slice();
+    if(state.q){
+      const q = state.q.toLowerCase();
+      rows = rows.filter((p) =>
+        (p.title || '').toLowerCase().includes(q) ||
+        (p.excerpt || '').toLowerCase().includes(q) ||
+        (p.tags || []).some((t) => t.toLowerCase().includes(q))
+      );
+    }
+    if(state.tag) rows = rows.filter((p) => (p.tags || []).includes(state.tag));
+    rows.sort((a, b) => new Date(b.date) - new Date(a.date));
+
+    const pages = Math.max(1, Math.ceil(rows.length / state.per));
+    if(state.page > pages) state.page = pages;
+    const start = (state.page - 1) * state.per;
+    const pageRows = rows.slice(start, start + state.per);
+
+    if(pageRows.length){
+      $grid.innerHTML = pageRows.map((p) => {
+        const url = (p.hreflang && p.hreflang[lang]) || `${lang==='tr'?'/tr':''}/article.html?slug=${p.slug}`;
+        const cover = p.cover || '';
+        const title = p.title || '';
+        const excerpt = p.excerpt || '';
+        const dateHuman = p.date ? new Date(p.date).toLocaleDateString(lang, {year:'numeric', month:'short', day:'2-digit'}) : '';
+        const firstTag = (p.tags && p.tags[0]) ? `#${p.tags[0]}` : '#greenairiva';
+        const datetimeAttr = p.date ? ` datetime="${p.date}"` : '';
+        const minutesText = `${p.readingMinutes || 5} ${lang==='tr' ? 'dk' : 'min'}`;
+        return `
+      <article class="ga-card">
+        <a class="ga-thumb" href="${url}">
+          <img loading="lazy" src="${cover}" alt="${title} cover">
+        </a>
+        <div class="ga-body">
+          <h3 class="ga-h3"><a href="${url}">${title}</a></h3>
+          <p class="ga-excerpt">${excerpt}</p>
+        </div>
+        <div class="ga-meta">
+          <div class="ga-meta-left">
+            <span class="ga-badge">${firstTag}</span>
+            <span class="ga-dot"></span>
+            <time${datetimeAttr}>${dateHuman}</time>
+            <span class="ga-sep">·</span>
+            <span class="ga-read">${minutesText}</span>
+          </div>
+          <div class="ga-meta-right">
+            <span class="ga-stat">${icons.eye}<b>0</b></span>
+            <span class="ga-stat">${icons.cmt}<b>0</b></span>
+            <span class="ga-stat">${icons.like}<b>0</b></span>
+          </div>
+        </div>
+      </article>`;
+      }).join('');
+    } else {
+      const emptyMessage = isError
+        ? (lang==='tr' ? 'Yazılar yüklenemedi.' : 'Unable to load insights.')
+        : (lang==='tr' ? 'Seçilen filtrelerle eşleşen yazı yok.' : 'No insights match your filters.');
+      $grid.innerHTML = `<div class="ga-empty">${emptyMessage}</div>`;
+    }
+
+    $pager.innerHTML = Array.from({length: pages}, (_, i) => `<button class="pg${i + 1 === state.page ? ' active' : ''}" data-page="${i + 1}">${i + 1}</button>`).join('');
+  }
+
+  document.addEventListener('click', (e) => {
+    const tag = e.target?.dataset?.tag;
+    const pg = e.target?.dataset?.page;
+    if(tag){
+      state.tag = (state.tag === tag ? null : tag);
+      state.page = 1;
+      buildTags();
+      render();
+    }
+    if(pg){
+      state.page = Number(pg);
+      render();
+    }
+  });
+
+  const debounce = (fn, ms) => { let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); }; };
+  if($search){
+    $search.addEventListener('input', debounce((e) => {
+      state.q = e.target.value;
+      state.page = 1;
+      render();
+    }, 120));
+  }
+}
+document.addEventListener('DOMContentLoaded', gaBlogBoardInit);
+

--- a/tr/index.html
+++ b/tr/index.html
@@ -75,26 +75,20 @@
     </div>
 </header>
 
-    <!-- Blog Main -->
-    <main class="container my-5">
-        <div class="row align-items-center mb-4">
-            <div class="col">
-                <h2 class="mb-0">İklim Kriziyle ilgili En Güncel Yazılar</h2>
-            </div>
-            <div class="col-auto">
-                <select class="form-select" id="postFilter" style="min-width:180px;">
-                    <option value="">Tüm Kategoriler</option>
-                </select>
-            </div>
+    <!-- GreenAiriva Blog Board -->
+    <section id="ga-board" class="ga-board">
+      <div class="container">
+        <h2 class="ga-title">Son Yazılar</h2>
+        <div class="ga-toolbar">
+          <div class="ga-tags" id="gaTagBar"></div>
+          <div class="ga-actions">
+            <input id="gaSearch" class="ga-search" placeholder="Yazılarda ara…" />
+          </div>
         </div>
-        <div id="postList"></div>
-        <div class="text-center my-4">
-            <button class="btn btn-success btn-lg px-5 py-2" id="loadMoreBtn" style="display:none;">
-                <span class="fw-semibold">Daha Fazla İçerik</span>
-                <i class="fas fa-angle-down ms-2"></i>
-            </button>
-        </div>
-    </main>
+        <div id="gaGrid" class="ga-grid"></div>
+        <div class="ga-pager" id="gaPager"></div>
+      </div>
+    </section>
 
    <!-- Contact-->
 <section class="page-section" id="contact">
@@ -158,31 +152,6 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://kit.fontawesome.com/yourfontawesomekit.js" crossorigin="anonymous"></script>
 <script src="../js/scripts.js"></script>
-
-<!-- Türkçe Kategori Override -->
-<script>
-  document.addEventListener("DOMContentLoaded", function () {
-    const lang = document.documentElement.lang || 'en';
-    if (lang !== 'tr') return;
-
-    const filter = document.getElementById("postFilter");
-    if (!filter) return;
-
-    const updateLabel = () => {
-      const defaultOption = filter.querySelector('option[value=""]');
-      if (defaultOption && defaultOption.textContent !== "Tüm Kategoriler") {
-        defaultOption.textContent = "Tüm Kategoriler";
-      }
-    };
-
-    // İlk düzeltmeyi yap
-    updateLabel();
-
-    // Değişiklikleri gözlemle
-    const observer = new MutationObserver(updateLabel);
-    observer.observe(filter, { childList: true, subtree: true });
-  });
-</script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the old blog list in EN/TR landing pages with the GreenAiriva board layout, including brand search, tag rail, and pager scaffolding
- introduce the dark-theme board styling for GreenAiriva cards, toolbars, meta footer, and pagination controls
- add the GreenAiriva blog board script that normalizes post data, powers filtering/search, and renders GA-styled cards with mock stats

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cabcc60f38832ea62bad602dc1d80b