### PR TITLE
feat(article): add sticky TOC, breadcrumb+hero, tag badges and tag-based related posts; a11y & dark-mode friendly

### DIFF
--- a/article.html
+++ b/article.html
@@ -28,7 +28,8 @@
 </head>
 <body id="page-top">
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+    <header id="top-nav">
+      <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
         <div class="container">
             <a class="navbar-brand" href="https://www.greenairiva.com.tr/"><img src="assets/img/navbar-logo.svg" alt="GreenAiriva logo" /></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
@@ -62,48 +63,44 @@
                 </ul>
             </div>
         </div>
-    </nav>
-<!-- Masthead -->
-<!--
-        <header class="masthead">
-    <div class="container">
-        <div class="masthead-heading">Rise<br>for a</div>
-        <div class="masthead-subheading-script">Cleaner</div>
-        <div class="masthead-heading">Planet</div>
-        <div class="masthead-btn-row">
-            <a class="btn btn-primary btn-xl text-uppercase" href="https://www.greenairiva.com.tr/about/#about">Discover Our Solutions</a>
-        </div>
-    </div>
-</header>
--->
-        <header class="masthead article-masthead" id="article-masthead">
-    <div class="container">
-        <div class="article-masthead-info">
-            <span id="article-category-head" class="badge bg-success me-2"></span>
-            <span id="article-date-head" class="text-light small"></span>
-            <h1 id="article-title-head" class="article-masthead-title text-white mt-2"></h1>
-        </div>
-    </div>
-</header>
+      </nav>
+    </header>
+    <div class="article-wrapper container">
+      <nav aria-label="Breadcrumb">
+        <ol class="breadcrumb">
+          <!-- JS dolduracak: Home › Blog › {title} -->
+        </ol>
+      </nav>
 
-<!-- Article Main -->
-<main class="container my-5" id="article-main">
-  <div class="row justify-content-center">
-    <div class="col-lg-10 col-xl-8">
-      <article class="blog-single border-0 shadow-none">
-        <img id="article-image" src="" alt="" class="img-fluid rounded mb-3 article-image">
-        <div class="mb-2">
-          <span id="article-category" class="badge bg-success me-2"></span>
-          <span id="article-date" class="text-muted small"></span>
+      <section class="hero-card">
+        <div class="hero-meta">
+          <h1 class="post-title"></h1>
+          <p class="post-byline">By <span class="post-author"></span> · <time class="post-date"></time></p>
         </div>
-        <h1 id="article-title" class="blog-title"></h1>
-        <div id="article-summary" class="lead text-muted mb-3"></div>
-        <div id="article-content" class="blog-content"></div>
-      </article>
-      <div id="article-notfound" class="alert alert-warning mt-4 article-notfound">Article not found.</div>
+        <figure class="hero-cover"><img class="hero-img" alt=""></figure>
+        <div class="post-abstract callout"></div>
+      </section>
+
+      <div id="article-notfound" class="alert alert-warning article-notfound" hidden>Article not found.</div>
+
+      <main class="article-layout">
+        <div class="left-spacer"></div>
+        <article class="article-content" id="article-content"><!-- md’den üretilen html burada --></article>
+        <aside class="toc-sidebar" aria-label="Table of contents">
+          <div class="toc-header">Table of contents</div>
+          <nav id="js-toc" class="toc"></nav>
+        </aside>
+      </main>
+
+      <section class="related-posts" id="related-posts">
+        <h2>Keep reading</h2>
+        <div class="card-grid" id="related-posts-grid"></div>
+      </section>
+
+      <section class="post-tags" id="post-tags" aria-label="Tags"></section>
     </div>
-  </div>
-</main>
+
+    <script type="application/ld+json" id="breadcrumb-jsonld"><!-- JS dolduracak --></script>
 
 
    <!-- Contact-->
@@ -169,59 +166,7 @@
 			<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 			<script src="https://kit.fontawesome.com/yourfontawesomekit.js" crossorigin="anonymous"></script>
                         <script src="js/scripts.js"></script>
-	<script>
-document.addEventListener('DOMContentLoaded', function () {
-  // 1. URL'den slug/id oku (?slug=2025-07-14-sera-gazlari gibi)
-  const params = new URLSearchParams(window.location.search);
-  const slug = params.get('slug');
-
-  // 2. posts.json'dan ilgili yazıyı bul
-  fetch('posts.json')
-    .then(response => response.json())
-    .then(posts => {
-      const post = posts.find(p => p.slug === slug);
-      if (!post) {
-        document.getElementById('article-notfound').style.display = 'block';
-        document.querySelector('.blog-single').style.display = 'none';
-        return;
-      }
-
-      if (post.image) {
-        document.getElementById('article-masthead').style.backgroundImage = `url('${post.image}')`;
-        document.getElementById('article-masthead').style.backgroundColor = "#212529";
-      }
-         document.getElementById('article-category-head').textContent = post.category || '';
-         document.getElementById('article-title-head').textContent = post.title || '';
-         document.getElementById('article-date-head').textContent = post.date ? new Date(post.date).toLocaleDateString('tr-TR', { day: '2-digit', month: 'long', year: 'numeric' }) : '';
-
-     
-      // 3. Alanları doldur
-//      if (post.image) {
-//        const img = document.getElementById('article-image');
-//        img.src = post.image;
-//        img.alt = post.title;
-//        img.style.display = 'block';
-//      }
-//      document.getElementById('article-category').textContent = post.category || '';
-//      document.getElementById('article-date').textContent = post.date ? new Date(post.date).toLocaleDateString('tr-TR', { day: '2-digit', month: 'long', year: 'numeric' }) : '';
-//      document.getElementById('article-title').textContent = post.title || '';
-//      document.getElementById('article-summary').textContent = post.summary || '';
-      // 4. İçerik dosyasını fetch et (ör: /posts/2025-07-14-sera-gazlari.md)
-      if (post.url) {
-        fetch(post.url)
-          .then(res => res.text())
-          .then(md => {
-            // Eğer markdown ise marked.js ile parse et, yoksa direkt göster
-            if (window.marked) {
-              document.getElementById('article-content').innerHTML = marked.parse(md);
-            } else {
-              document.getElementById('article-content').textContent = md;
-            }
-          });
-      }
-    });
-});
-</script>
+	
 <!-- Optional: Markdown desteği için -->
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1823,7 +1823,12 @@ header.masthead.article-masthead::before {
 }
 
 .article-notfound {
-  display: none;
+  display: block;
+  margin: 2rem 0;
+}
+
+.article-notfound[hidden] {
+  display: none !important;
 }
 
 .footer-social-icon {
@@ -2223,3 +2228,222 @@ h1, h2, h3, h4, h5 {
 .ga-pager{ display:flex; justify-content:center; gap:.4rem; margin-top:1rem; }
 .ga-pager .pg{ background:#151923; color:#cfd8ea; border:1px solid #222a3a; padding:.5rem .75rem; border-radius:.5rem; }
 .ga-pager .pg.active, .ga-pager .pg:hover{ background:#2a3347; color:#fff; border-color:#2f3a51; }
+
+/* Article layout enhancements */
+.article-wrapper {
+  margin: 6rem auto 4rem;
+  max-width: 1200px;
+}
+
+.article-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: 1fr min(800px, 100%) 320px;
+  align-items: start;
+}
+
+.article-layout .article-content {
+  min-width: 0;
+}
+
+@media (max-width: 1200px) {
+  .article-layout {
+    grid-template-columns: min(800px, 100%);
+  }
+  .article-layout .left-spacer {
+    display: none;
+  }
+  .toc-sidebar {
+    display: none;
+  }
+}
+
+.hero-card {
+  background: var(--surface, rgba(255, 255, 255, 0.06));
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(6px);
+  margin-bottom: 2rem;
+}
+
+.hero-card .hero-img {
+  width: 100%;
+  height: auto;
+  border-radius: 0.75rem;
+  display: block;
+}
+
+.hero-card .post-title {
+  margin-bottom: 0.5rem;
+}
+
+.post-byline {
+  opacity: 0.8;
+  font-size: 0.95rem;
+  margin: 0.25rem 0 1rem;
+}
+
+.post-abstract.callout {
+  border-left: 4px solid var(--primary, #38bdf8);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="dark"] .post-abstract.callout {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.toc-sidebar {
+  position: sticky;
+  top: 96px;
+  align-self: start;
+  max-height: calc(100vh - 120px);
+  overflow: auto;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background: var(--surface, rgba(255, 255, 255, 0.04));
+}
+
+.toc-header {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  opacity: 0.9;
+}
+
+.toc ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 0.5rem;
+}
+
+.toc li {
+  margin: 0.125rem 0;
+}
+
+.toc .depth-3 {
+  padding-left: 0.75rem;
+}
+
+.toc .depth-4 {
+  padding-left: 1.5rem;
+}
+
+.toc a {
+  display: block;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.95rem;
+  opacity: 0.8;
+  text-decoration: none;
+  border-radius: 0.375rem;
+  color: inherit;
+}
+
+.toc a[aria-current="true"] {
+  opacity: 1;
+  font-weight: 600;
+  outline: 2px solid var(--primary, #38bdf8);
+}
+
+.article-content h2,
+.article-content h3,
+.article-content h4 {
+  scroll-margin-top: 96px;
+}
+
+.related-posts {
+  margin-top: 3rem;
+}
+
+.related-posts .card-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 900px) {
+  .related-posts .card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .related-posts .card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.post-card {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: var(--surface, rgba(255, 255, 255, 0.04));
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.post-card .card-cover {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  display: block;
+}
+
+.post-card .card-body {
+  padding: 0.75rem 1rem;
+}
+
+.post-card .card-excerpt {
+  font-size: 0.95rem;
+  opacity: 0.85;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 2rem;
+}
+
+.post-tags .tag {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  background: var(--chip-bg, rgba(255, 255, 255, 0.08));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-decoration: none;
+  color: inherit;
+}
+
+.post-tags .tag:hover {
+  filter: brightness(1.1);
+}
+
+.breadcrumb {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.breadcrumb li::after {
+  content: "\203A";
+  margin-left: 0.5rem;
+  opacity: 0.6;
+}
+
+.breadcrumb li:last-child::after {
+  content: "";
+}
+
+.breadcrumb a {
+  text-decoration: none;
+  opacity: 0.85;
+  color: inherit;
+}

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -385,3 +385,680 @@ function gaBlogBoardInit(){
 }
 document.addEventListener('DOMContentLoaded', gaBlogBoardInit);
 
+
+// ==== ARTICLE PAGE ENHANCEMENTS ====
+const ARTICLE_JSON_PATH = 'posts.json';
+const ARTICLE_MAX_RELATED = 6;
+const ARTICLE_FALLBACK_COVER = 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Article" preserveAspectRatio="xMidYMid slice"><rect width="1200" height="800" fill="#0f172a"/><path d="M150 640h900" stroke="#1e293b" stroke-width="40" stroke-linecap="round"/><rect x="220" y="220" width="760" height="260" fill="#1e293b" rx="32"/><text x="50%" y="48%" font-family="Montserrat, sans-serif" font-size="120" fill="#334155" text-anchor="middle">GreenAiriva</text></svg>');
+
+const articleState = {
+  posts: [],
+  post: null,
+  slug: ''
+};
+
+function prefersReducedMotion() {
+  return Boolean(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+}
+
+function slugifyText(text, fallback = 'section') {
+  const base = String(text || '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .trim()
+    .replace(/\s+/g, '-');
+  return base || fallback;
+}
+
+function getArticleSlugFromLocation() {
+  const params = new URLSearchParams(window.location.search);
+  const querySlug = params.get('slug');
+  if (querySlug) {
+    return decodeURIComponent(querySlug);
+  }
+  const pathMatch = window.location.pathname.match(/([^/]+?)(?:\.html)?$/);
+  if (pathMatch && pathMatch[1] && pathMatch[1] !== 'article') {
+    return pathMatch[1];
+  }
+  return '';
+}
+
+function normalizePost(raw = {}) {
+  const title = String(raw.title || raw.name || '').trim() || 'Untitled';
+  let slug = String(raw.slug || '').trim();
+  const urlCandidate = raw.url || raw.link || raw.permalink || '';
+  const pathCandidate = raw.path || raw.file || '';
+  if (!slug && urlCandidate) {
+    const parts = urlCandidate.split('/').filter(Boolean);
+    const last = parts[parts.length - 1] || '';
+    slug = last.replace(/\.[^.]+$/, '');
+  }
+  if (!slug && pathCandidate) {
+    const parts = String(pathCandidate).split('/').filter(Boolean);
+    const last = parts[parts.length - 1] || '';
+    slug = last.replace(/\.[^.]+$/, '');
+  }
+  if (!slug) {
+    slug = slugifyText(title);
+  }
+  slug = slug.toLowerCase();
+
+  let content = raw.content || raw.body || '';
+  const isMarkdownUrl = (value) => /\.md(\?.*)?$/i.test(value || '');
+  if (!content && isMarkdownUrl(urlCandidate)) {
+    content = urlCandidate;
+  }
+  if (!content && isMarkdownUrl(pathCandidate)) {
+    content = pathCandidate;
+  }
+
+  let canonicalUrl = '';
+  if (urlCandidate && !isMarkdownUrl(urlCandidate)) {
+    canonicalUrl = urlCandidate;
+  }
+  if (!canonicalUrl) {
+    canonicalUrl = `article.html?slug=${encodeURIComponent(slug)}`;
+  }
+
+  const dateSource = raw.date || raw.published_at || raw.publishedAt || raw.publish_date || raw.published || '';
+  const dateObj = dateSource ? new Date(dateSource) : null;
+  const dateValid = dateObj && !Number.isNaN(dateObj.getTime()) ? dateObj : null;
+  const dateISO = dateValid ? dateValid.toISOString() : '';
+
+  const abstract = raw.abstract || raw.excerpt || raw.summary || raw.description || '';
+  const cover = raw.cover || raw.image || raw.thumbnail || '';
+
+  let author = '';
+  if (typeof raw.author === 'string') {
+    author = raw.author;
+  } else if (raw.author && typeof raw.author.name === 'string') {
+    author = raw.author.name;
+  } else if (Array.isArray(raw.authors) && raw.authors.length) {
+    const firstAuthor = raw.authors[0];
+    if (typeof firstAuthor === 'string') {
+      author = firstAuthor;
+    } else if (firstAuthor && typeof firstAuthor.name === 'string') {
+      author = firstAuthor.name;
+    }
+  }
+
+  const tagsSource = raw.tags || raw.categories || raw.labels || [];
+  let tags = [];
+  if (Array.isArray(tagsSource)) {
+    tags = tagsSource.flatMap((tag) => {
+      if (typeof tag === 'string') {
+        return tag;
+      }
+      if (tag && typeof tag.name === 'string') {
+        return tag.name;
+      }
+      return [];
+    });
+  } else if (typeof tagsSource === 'string') {
+    tags = tagsSource.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+  tags = Array.from(new Set(tags.filter(Boolean)));
+
+  return {
+    title,
+    slug,
+    url: canonicalUrl,
+    content,
+    date: dateSource || '',
+    dateISO,
+    dateObj: dateValid || null,
+    abstract,
+    cover,
+    author,
+    tags,
+    summary: abstract || raw.summary || '',
+    image: cover || raw.image || '',
+    raw
+  };
+}
+
+function showArticleNotFound(message) {
+  const sectionsToHide = [
+    document.querySelector('.hero-card'),
+    document.querySelector('.article-layout'),
+    document.getElementById('related-posts'),
+    document.getElementById('post-tags'),
+    document.querySelector('.article-wrapper nav[aria-label="Breadcrumb"]')
+  ];
+  sectionsToHide.forEach((element) => {
+    if (element) {
+      element.style.display = 'none';
+    }
+  });
+  const notFound = document.getElementById('article-notfound');
+  if (notFound) {
+    if (message) {
+      notFound.textContent = message;
+    }
+    notFound.hidden = false;
+  }
+}
+
+function hideArticleNotFound() {
+  const notFound = document.getElementById('article-notfound');
+  if (notFound) {
+    notFound.hidden = true;
+  }
+  const sectionsToShow = [
+    document.querySelector('.article-wrapper nav[aria-label="Breadcrumb"]'),
+    document.querySelector('.hero-card'),
+    document.querySelector('.article-layout'),
+    document.getElementById('related-posts'),
+    document.getElementById('post-tags')
+  ];
+  sectionsToShow.forEach((element) => {
+    if (element) {
+      element.style.display = '';
+    }
+  });
+}
+
+function absoluteUrl(path) {
+  try {
+    return new URL(path, window.location.origin).href;
+  } catch (error) {
+    return path;
+  }
+}
+
+async function renderArticleContent(post) {
+  const container = document.querySelector('.article-content');
+  if (!container || !post) {
+    return;
+  }
+  container.innerHTML = '';
+  if (!post.content) {
+    return;
+  }
+  try {
+    const response = await fetch(post.content);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch content: ${response.status}`);
+    }
+    const markdown = await response.text();
+    if (window.marked && typeof window.marked.parse === 'function') {
+      container.innerHTML = window.marked.parse(markdown);
+    } else {
+      container.textContent = markdown;
+    }
+  } catch (error) {
+    console.error('Unable to load article content', error);
+    container.innerHTML = '<p class="alert alert-warning">Unable to load article content at the moment.</p>';
+  }
+}
+
+function initBreadcrumb() {
+  const post = articleState.post;
+  if (!post) {
+    return;
+  }
+  const breadcrumbList = document.querySelector('.breadcrumb');
+  if (!breadcrumbList) {
+    return;
+  }
+  breadcrumbList.innerHTML = '';
+
+  const homeUrl = absoluteUrl('/');
+  const blogUrl = absoluteUrl('index.html');
+  const articleUrl = absoluteUrl(window.location.pathname + window.location.search);
+
+  const crumbs = [
+    { label: 'Home', href: homeUrl },
+    { label: 'Blog', href: blogUrl },
+    { label: post.title, href: null }
+  ];
+
+  crumbs.forEach((crumb, index) => {
+    const li = document.createElement('li');
+    if (crumb.href && index !== crumbs.length - 1) {
+      const anchor = document.createElement('a');
+      anchor.href = crumb.href;
+      anchor.textContent = crumb.label;
+      li.appendChild(anchor);
+    } else {
+      li.textContent = crumb.label;
+      li.setAttribute('aria-current', 'page');
+    }
+    breadcrumbList.appendChild(li);
+  });
+
+  const breadcrumbJson = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: crumbs.map((crumb, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: crumb.label,
+      item: crumb.href || articleUrl
+    }))
+  };
+  const jsonLdElement = document.getElementById('breadcrumb-jsonld');
+  if (jsonLdElement) {
+    jsonLdElement.textContent = JSON.stringify(breadcrumbJson, null, 2);
+  }
+}
+
+function initHero() {
+  const post = articleState.post;
+  if (!post) {
+    return;
+  }
+  const heroCard = document.querySelector('.hero-card');
+  if (!heroCard) {
+    return;
+  }
+
+  const titleEl = heroCard.querySelector('.post-title');
+  if (titleEl) {
+    titleEl.textContent = post.title;
+  }
+
+  const bylineEl = heroCard.querySelector('.post-byline');
+  if (bylineEl) {
+    const authorName = post.author || 'GreenAiriva Team';
+    const segments = [];
+    if (authorName) {
+      segments.push({ type: 'author', value: authorName });
+    }
+    if (post.dateObj) {
+      const formattedDate = post.dateObj.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric'
+      });
+      segments.push({ type: 'date', value: formattedDate, datetime: post.dateISO });
+    }
+
+    if (segments.length === 0) {
+      bylineEl.style.display = 'none';
+    } else {
+      bylineEl.style.display = '';
+      bylineEl.innerHTML = '';
+      segments.forEach((segment, index) => {
+        if (segment.type === 'author') {
+          const authorText = document.createTextNode('By ');
+          const authorSpan = document.createElement('span');
+          authorSpan.className = 'post-author';
+          authorSpan.textContent = segment.value;
+          bylineEl.append(authorText, authorSpan);
+        }
+        if (segment.type === 'date') {
+          if (index > 0) {
+            bylineEl.append(document.createTextNode(' · '));
+          }
+          const timeEl = document.createElement('time');
+          timeEl.className = 'post-date';
+          if (segment.datetime) {
+            timeEl.setAttribute('datetime', segment.datetime);
+          }
+          timeEl.textContent = segment.value;
+          bylineEl.appendChild(timeEl);
+        }
+      });
+    }
+  }
+
+  const abstractEl = heroCard.querySelector('.post-abstract');
+  if (abstractEl) {
+    if (post.abstract) {
+      abstractEl.textContent = post.abstract;
+      abstractEl.style.display = '';
+    } else {
+      abstractEl.style.display = 'none';
+    }
+  }
+
+  const heroFigure = heroCard.querySelector('.hero-cover');
+  const heroImg = heroCard.querySelector('.hero-img');
+  if (heroImg) {
+    if (post.cover) {
+      heroImg.src = post.cover;
+      heroImg.alt = `${post.title} cover image`;
+      heroImg.loading = 'lazy';
+      if (heroFigure) {
+        heroFigure.style.display = '';
+      }
+    } else if (heroFigure) {
+      heroFigure.style.display = 'none';
+    }
+  }
+
+  if (post.title) {
+    document.title = `${post.title} – GreenAiriva Blog`;
+  }
+}
+
+function initToc() {
+  const article = document.querySelector('.article-content');
+  const tocNav = document.getElementById('js-toc');
+  const tocSidebar = document.querySelector('.toc-sidebar');
+  if (!article || !tocNav) {
+    return;
+  }
+
+  const headings = Array.from(article.querySelectorAll('h2, h3, h4'));
+  if (!headings.length) {
+    tocNav.innerHTML = '';
+    if (tocSidebar) {
+      tocSidebar.hidden = true;
+    }
+    return;
+  }
+
+  if (tocSidebar) {
+    tocSidebar.hidden = false;
+  }
+
+  const slugRegistry = Object.create(null);
+  const getHeadingId = (heading) => {
+    if (heading.id) {
+      return heading.id;
+    }
+    const base = slugifyText(heading.textContent, 'section');
+    const count = slugRegistry[base] || 0;
+    slugRegistry[base] = count + 1;
+    const slug = count ? `${base}-${count}` : base;
+    heading.id = slug;
+    return slug;
+  };
+
+  const rootList = document.createElement('ul');
+  const lastItems = { 2: null, 3: null, 4: null };
+  const linkRegistry = new Map();
+
+  headings.forEach((heading) => {
+    const level = Number(heading.tagName.replace('H', ''));
+    const headingId = getHeadingId(heading);
+    const listItem = document.createElement('li');
+    listItem.classList.add(`depth-${level}`);
+    const link = document.createElement('a');
+    link.href = `#${headingId}`;
+    link.textContent = heading.textContent.trim();
+    link.dataset.headingId = headingId;
+    listItem.appendChild(link);
+
+    if (level === 2) {
+      rootList.appendChild(listItem);
+      lastItems[2] = listItem;
+      lastItems[3] = null;
+      lastItems[4] = null;
+    } else if (level === 3) {
+      const parent = lastItems[2];
+      if (parent) {
+        let childList = parent.querySelector(':scope > ul');
+        if (!childList) {
+          childList = document.createElement('ul');
+          parent.appendChild(childList);
+        }
+        childList.appendChild(listItem);
+      } else {
+        rootList.appendChild(listItem);
+      }
+      lastItems[3] = listItem;
+      lastItems[4] = null;
+    } else if (level === 4) {
+      const parent = lastItems[3] || lastItems[2];
+      if (parent) {
+        let childList = parent.querySelector(':scope > ul');
+        if (!childList) {
+          childList = document.createElement('ul');
+          parent.appendChild(childList);
+        }
+        childList.appendChild(listItem);
+      } else {
+        rootList.appendChild(listItem);
+      }
+      lastItems[4] = listItem;
+    }
+
+    linkRegistry.set(headingId, link);
+  });
+
+  tocNav.innerHTML = '';
+  tocNav.appendChild(rootList);
+
+  const setActiveLink = (id) => {
+    tocNav.querySelectorAll('a[aria-current="true"]').forEach((activeLink) => {
+      if (activeLink.dataset.headingId !== id) {
+        activeLink.removeAttribute('aria-current');
+      }
+    });
+    const targetLink = linkRegistry.get(id);
+    if (targetLink) {
+      targetLink.setAttribute('aria-current', 'true');
+    }
+  };
+
+  const updateHash = (id) => {
+    if (!id || window.location.hash === `#${id}` || !history.replaceState) {
+      return;
+    }
+    history.replaceState(null, '', `#${id}`);
+  };
+
+  const scrollToHeading = (id) => {
+    const heading = document.getElementById(id);
+    if (!heading) {
+      return;
+    }
+    heading.scrollIntoView({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
+  };
+
+  tocNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      const id = event.currentTarget.dataset.headingId;
+      if (!id) {
+        return;
+      }
+      setActiveLink(id);
+      scrollToHeading(id);
+      updateHash(id);
+    });
+  });
+
+  const observer = new IntersectionObserver((entries) => {
+    const visible = entries.filter((entry) => entry.isIntersecting);
+    if (!visible.length) {
+      return;
+    }
+    visible.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+    const topEntry = visible[0];
+    const id = topEntry.target.id;
+    if (id) {
+      setActiveLink(id);
+      updateHash(id);
+    }
+  }, {
+    rootMargin: '-20% 0px -65% 0px',
+    threshold: [0, 0.1, 0.25]
+  });
+
+  headings.forEach((heading) => observer.observe(heading));
+
+  if (window.location.hash) {
+    const hashId = decodeURIComponent(window.location.hash.replace('#', ''));
+    if (hashId) {
+      setTimeout(() => {
+        setActiveLink(hashId);
+        scrollToHeading(hashId);
+      }, 100);
+    }
+  } else if (headings[0]) {
+    setActiveLink(headings[0].id);
+  }
+}
+
+function slugifyTag(tag) {
+  return slugifyText(tag, '').replace(/^-+|-+$/g, '') || slugifyText(tag, 'tag');
+}
+
+const tagUrlCache = new Map();
+async function resolveTagHref(tagSlug) {
+  if (tagUrlCache.has(tagSlug)) {
+    return tagUrlCache.get(tagSlug);
+  }
+  const fallback = `/?tag=${encodeURIComponent(tagSlug)}`;
+  if (window.location.protocol === 'file:' || typeof fetch !== 'function') {
+    tagUrlCache.set(tagSlug, fallback);
+    return fallback;
+  }
+  const candidates = [
+    `tags/${tagSlug}/`,
+    `tags/${tagSlug}.html`,
+    `/tags/${tagSlug}/`,
+    `/tags/${tagSlug}.html`
+  ];
+  for (const candidate of candidates) {
+    try {
+      const response = await fetch(candidate, { method: 'HEAD' });
+      if (response.ok) {
+        tagUrlCache.set(tagSlug, candidate);
+        return candidate;
+      }
+    } catch (error) {
+      // ignore and try next candidate
+    }
+  }
+  tagUrlCache.set(tagSlug, fallback);
+  return fallback;
+}
+
+async function initTags() {
+  const post = articleState.post;
+  const container = document.getElementById('post-tags');
+  if (!post || !container) {
+    return;
+  }
+  const tags = Array.isArray(post.tags) ? post.tags.filter(Boolean) : [];
+  if (!tags.length) {
+    container.innerHTML = '';
+    container.hidden = true;
+    return;
+  }
+  container.hidden = false;
+  container.innerHTML = '';
+  const links = await Promise.all(tags.map(async (tag) => {
+    const slug = slugifyTag(tag);
+    const href = await resolveTagHref(slug);
+    const anchor = document.createElement('a');
+    anchor.className = 'tag';
+    anchor.href = href;
+    anchor.textContent = `#${tag}`;
+    anchor.setAttribute('data-tag-slug', slug);
+    return anchor;
+  }));
+  links.forEach((anchor) => container.appendChild(anchor));
+}
+
+function compareByDateDesc(a, b) {
+  const aTime = a.dateObj ? a.dateObj.getTime() : 0;
+  const bTime = b.dateObj ? b.dateObj.getTime() : 0;
+  return bTime - aTime;
+}
+
+function createRelatedCard(post) {
+  const dateText = post.dateObj
+    ? post.dateObj.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+    : '';
+  const dateISO = post.dateISO || '';
+  const cover = post.cover || ARTICLE_FALLBACK_COVER;
+  const abstract = post.abstract || post.summary || '';
+  return `
+  <article class="post-card">
+    <a href="${post.url}" class="card-link">
+      <img class="card-cover" src="${cover}" alt="${post.title}" loading="lazy">
+      <div class="card-body">
+        <h3 class="card-title">${post.title}</h3>
+        <p class="card-excerpt">${abstract}</p>
+        <div class="card-meta"><time datetime="${dateISO}">${dateText}</time></div>
+      </div>
+    </a>
+  </article>
+  `;
+}
+
+function initRelated() {
+  const post = articleState.post;
+  const posts = articleState.posts;
+  const grid = document.getElementById('related-posts-grid');
+  const section = document.getElementById('related-posts');
+  if (!post || !grid || !section) {
+    return;
+  }
+  const others = posts.filter((entry) => entry.slug !== post.slug);
+  if (!others.length) {
+    section.style.display = 'none';
+    return;
+  }
+  const currentTags = new Set((post.tags || []).map((tag) => tag.toLowerCase()));
+  const hasTags = currentTags.size > 0;
+  let related = [];
+  if (hasTags) {
+    related = others.filter((entry) => (entry.tags || []).some((tag) => currentTags.has(tag.toLowerCase())));
+  }
+  if (!related.length) {
+    related = others.slice().sort(compareByDateDesc).slice(0, Math.min(3, others.length));
+  } else {
+    related = related.slice().sort(compareByDateDesc).slice(0, ARTICLE_MAX_RELATED);
+  }
+  if (!related.length) {
+    section.style.display = 'none';
+    return;
+  }
+  section.style.display = '';
+  grid.innerHTML = related.map((entry) => createRelatedCard(entry)).join('');
+}
+
+async function setupArticlePage() {
+  const articleContainer = document.querySelector('.article-content');
+  if (!articleContainer) {
+    return;
+  }
+  const slug = getArticleSlugFromLocation();
+  articleState.slug = slug;
+  if (!slug) {
+    showArticleNotFound('Article not found.');
+    return;
+  }
+
+  try {
+    const response = await fetch(ARTICLE_JSON_PATH);
+    if (!response.ok) {
+      throw new Error(`Failed to load posts: ${response.status}`);
+    }
+    const rawPosts = await response.json();
+    const normalizedPosts = rawPosts.map((item) => normalizePost(item));
+    articleState.posts = normalizedPosts;
+    const slugLower = slug.toLowerCase();
+    const current = normalizedPosts.find((item) => item.slug === slugLower || (item.raw && item.raw.slug && String(item.raw.slug).toLowerCase() === slugLower));
+    if (!current) {
+      showArticleNotFound('Article not found.');
+      return;
+    }
+    articleState.post = current;
+    hideArticleNotFound();
+    initBreadcrumb();
+    initHero();
+    await renderArticleContent(current);
+    initToc();
+    await initTags();
+    initRelated();
+  } catch (error) {
+    console.error('Unable to set up article page', error);
+    showArticleNotFound('Unable to load article. Please try again later.');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.querySelector('.article-content')) {
+    setupArticlePage();
+  }
+});

--- a/posts.json
+++ b/posts.json
@@ -2,28 +2,43 @@
   {
     "slug": "2025-07-14-social-cost-ghg",
     "title": "Social Cost of Greenhouse Gases: EPA SC-GHG Report",
+    "url": "article.html?slug=2025-07-14-social-cost-ghg",
+    "content": "posts/2025-07-15-social-cost.md",
     "date": "2025-07-14",
-    "category": ["EPA","Greenhouse Gases"],
+    "category": ["EPA", "Greenhouse Gases"],
     "summary": "Sera gazlarının sosyal maliyeti, atmosfere salınan gazların gelecekte yaratacağı çevresel ve ekonomik zararların bugünkü parasal değeridir. Bu çalışma, EPA'nın 2023 SC-GHG raporunu temel alarak, Türkiye özelinde Ankara ili için bir hesaplama sunmakta ve GreenAiriva’nın yenilikçi çözümleriyle sosyal maliyet azaltımına katkılarını analiz etmektedir.",
+    "abstract": "Sera gazlarının sosyal maliyeti, atmosfere salınan gazların gelecekte yaratacağı çevresel ve ekonomik zararların bugünkü parasal değeridir. Bu çalışma, EPA'nın 2023 SC-GHG raporunu temel alarak, Türkiye özelinde Ankara ili için bir hesaplama sunmakta ve GreenAiriva’nın yenilikçi çözümleriyle sosyal maliyet azaltımına katkılarını analiz etmektedir.",
     "image": "assets/img/blog/1.jpg",
-    "url": "posts/2025-07-15-social-cost.md"
+    "cover": "assets/img/blog/1.jpg",
+    "author": "GreenAiriva Research Team",
+    "tags": ["EPA", "Social Cost", "Climate Policy"]
   },
   {
     "slug": "2025-07-10-hava-kalitesi-greenairiva",
     "title": "Hava Kalitesi Ölçümleri ve GreenAiriva Çözümleri",
+    "url": "article.html?slug=2025-07-10-hava-kalitesi-greenairiva",
+    "content": "posts/2025-07-14-sera-gazlari.md",
     "date": "2025-07-10",
     "category": "Greenhouse Gases",
     "summary": "Bu yazıda, hava kalitesi ölçüm metodolojileri ve GreenAiriva'nın yenilikçi teknolojileri anlatılıyor.",
+    "abstract": "Bu yazıda, hava kalitesi ölçüm metodolojileri ve GreenAiriva'nın yenilikçi teknolojileri anlatılıyor.",
     "image": "assets/img/blog/2.jpg",
-    "url": "posts/2025-07-14-sera-gazlari.md"
+    "cover": "assets/img/blog/2.jpg",
+    "author": "GreenAiriva Data Team",
+    "tags": ["Air Quality", "Monitoring", "GreenAiriva"]
   },
   {
-    "slug": "2025-07-16-Sehir-ici-Hava-Filtreleme",
+    "slug": "2025-07-16-sehir-ici-hava-filtreleme",
     "title": "Kentlerde Aktif Hava Temizleme Teknolojileri: Günümüz Yaklaşımları, Potansiyel ve Sınırlar",
+    "url": "article.html?slug=2025-07-16-sehir-ici-hava-filtreleme",
+    "content": "posts/2025-07-16-Sehir-ici-Hava-Filtreleme.md",
     "date": "2025-07-16",
     "category": ["urban air cleaning", "active air filters", "CO2 capture", "green tech"],
     "summary": "Kentlerde PM, NOx ve sera gazları kaynaklı hava kirliliği sağlık ve iklimi tehdit ediyor. Yosun filtreleri, iyonizasyon kuleleri ve DAC gibi çözümler sınırlı kalıyor. GreenAiriva, çok katmanlı adsorban teknolojisi, gerçek zamanlı veri analizi ve güneş enerjisiyle çalışarak farklı kirleticileri hedef alıyor. Bu sayede mevcut teknolojilerdeki boşlukları dolduruyor ve kentsel hava temizliğinde yenilikçi, sürdürülebilir bir çözüm sunuyor.",
+    "abstract": "Kentlerde PM, NOx ve sera gazları kaynaklı hava kirliliği sağlık ve iklimi tehdit ediyor. Yosun filtreleri, iyonizasyon kuleleri ve DAC gibi çözümler sınırlı kalıyor. GreenAiriva, çok katmanlı adsorban teknolojisi, gerçek zamanlı veri analizi ve güneş enerjisiyle çalışarak farklı kirleticileri hedef alıyor. Bu sayede mevcut teknolojilerdeki boşlukları dolduruyor ve kentsel hava temizliğinde yenilikçi, sürdürülebilir bir çözüm sunuyor.",
     "image": "assets/img/blog/2025-07-16-Sehir-ici-Hava-Filtreleme/2025-07-16-Sehir-ici-Hava-Filtreleme.png",
-    "url": "posts/2025-07-16-Sehir-ici-Hava-Filtreleme.md"
+    "cover": "assets/img/blog/2025-07-16-Sehir-ici-Hava-Filtreleme/2025-07-16-Sehir-ici-Hava-Filtreleme.png",
+    "author": "GreenAiriva R&D Team",
+    "tags": ["Urban Air", "CO2 Capture", "Green Tech"]
   }
 ]


### PR DESCRIPTION
## Summary
- refactor the article template to introduce breadcrumb navigation, hero details, a dedicated article grid with sticky TOC, related grid, and tag badges
- extend the shared script with article-specific helpers for metadata normalization, hero, breadcrumb, sticky TOC, tag links, and related content, plus JSON-LD output
- add responsive styling for the new layout components and enrich post metadata with covers, abstracts, authors, and tag arrays

## Testing
- python -m json.tool posts.json


------
https://chatgpt.com/codex/tasks/task_e_68cad9e32c3c832ebdaf688b3b3916fe