### PR TITLE
feat(tr): localize article hero experience

### DIFF
--- a/article.html
+++ b/article.html
@@ -66,20 +66,22 @@
       </nav>
     </header>
     <div class="article-wrapper container">
-      <nav aria-label="Breadcrumb">
-        <ol class="breadcrumb">
-          <!-- JS dolduracak: Home › Blog › {title} -->
-        </ol>
-      </nav>
-
       <section class="hero-card">
         <div class="hero-meta">
           <h1 class="post-title"></h1>
           <p class="post-byline">By <span class="post-author"></span> · <time class="post-date"></time></p>
         </div>
-        <figure class="hero-cover"><img class="hero-img" alt=""></figure>
+        <figure class="hero-cover">
+          <img class="hero-img" id="article-hero-img" alt="">
+        </figure>
         <div class="post-abstract callout"></div>
       </section>
+
+      <nav aria-label="Breadcrumb">
+        <ol class="breadcrumb">
+          <!-- JS dolduracak: Home › Blog › {title} -->
+        </ol>
+      </nav>
 
       <div id="article-notfound" class="alert alert-warning article-notfound" hidden>Article not found.</div>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2267,11 +2267,27 @@ h1, h2, h3, h4, h5 {
   margin-bottom: 2rem;
 }
 
-.hero-card .hero-img {
+.hero-card .hero-cover {
   width: 100%;
+  height: clamp(220px, 36vh, 420px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface, rgba(255, 255, 255, 0.06));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1rem;
+  overflow: hidden;
+  margin: 0.75rem 0 0;
+}
+
+.hero-card .hero-cover .hero-img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
   height: auto;
-  border-radius: 0.75rem;
+  object-fit: contain;
   display: block;
+  border-radius: 0.75rem;
 }
 
 .hero-card .post-title {
@@ -2304,6 +2320,15 @@ h1, h2, h3, h4, h5 {
   border-radius: 0.75rem;
   padding: 1rem;
   background: var(--surface, rgba(255, 255, 255, 0.04));
+}
+
+.article-content img,
+.article-content figure img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 1rem auto;
+  border-radius: 0.75rem;
 }
 
 .toc-header {
@@ -2405,22 +2430,26 @@ h1, h2, h3, h4, h5 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 2rem;
+  margin-top: 1.25rem;
 }
 
 .post-tags .tag {
-  display: inline-block;
-  padding: 0.25rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.7rem;
+  background: #f1f5f9;
+  border: 1px solid #e2e8f0;
   border-radius: 999px;
   font-size: 0.9rem;
-  background: var(--chip-bg, rgba(255, 255, 255, 0.08));
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: #334155;
   text-decoration: none;
-  color: inherit;
+  transition: background 0.2s, border-color 0.2s, transform 0.12s;
 }
 
 .post-tags .tag:hover {
-  filter: brightness(1.1);
+  background: #eafaf0;
+  border-color: #bbf7d0;
+  transform: translateY(-1px);
 }
 
 .breadcrumb {
@@ -2432,18 +2461,26 @@ h1, h2, h3, h4, h5 {
   flex-wrap: wrap;
 }
 
+.breadcrumb a {
+  text-decoration: none;
+  opacity: 0.85;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.5rem;
+  transition: background-color 0.2s, color 0.2s, opacity 0.2s;
+}
+
+.breadcrumb a:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  opacity: 1;
+}
+
 .breadcrumb li::after {
-  content: "\203A";
-  margin-left: 0.5rem;
+  content: "›";
+  margin-left: 0.35rem;
   opacity: 0.6;
 }
 
 .breadcrumb li:last-child::after {
   content: "";
-}
-
-.breadcrumb a {
-  text-decoration: none;
-  opacity: 0.85;
-  color: inherit;
 }

--- a/tr/article.html
+++ b/tr/article.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="tr">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="description" content="GreenAiriva is an innovative air purification solution that captures particulate matter and greenhouse gases, improving urban air quality and contributing to climate action." />
     <meta name="author" content="GreenAiriva" />
-    <title>GreenAiriva – Blog of the Most Innovative Air Purification Solution</title>
+    <title>GreenAiriva – En Yenilikçi Hava Kalitesi İyileştirme Sistemi Blog Sayfası</title>
     <link rel="icon" type="image/x-icon" href="../assets/favicon.svg" />
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css" />
     <link href="https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700" rel="stylesheet" type="text/css" />
 <!-- Bootstrap/Genel -->
-	<link href="../css/styles.css" rel="stylesheet" />
+        <link href="../css/styles.css" rel="stylesheet" />
     <style>
         .lang-switch {
             display: inline-block;
@@ -28,7 +28,8 @@
 </head>
 <body id="page-top">
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+    <header id="top-nav">
+      <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
         <div class="container">
             <a class="navbar-brand" href="https://www.greenairiva.com.tr/"><img src="../assets/img/navbar-logo.svg" alt="GreenAiriva logo" /></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
@@ -49,69 +50,67 @@
                   <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="aboutDropdown" data-bs-toggle="dropdown" aria-expanded="false">Hakkımızda</a>
                     <ul class="dropdown-menu custom-dropdown-menu" aria-labelledby="aboutDropdown">
-			<li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#about">Hakkımızda</a></li>
-                    	<li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#vision">Vizyon</a></li>
-                    	<li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#mission">Misyon</a></li>
-         		<li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/about/tr/#whyus">Neden GreenAiriva?</a></li>
-                   	<li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#contribution">Sosyal ve Çevresel Katkı</a></li>
+                        <li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#about">Hakkımızda</a></li>
+                        <li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#vision">Vizyon</a></li>
+                        <li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#mission">Misyon</a></li>
+                        <li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/about/tr/#whyus">Neden GreenAiriva?</a></li>
+                        <li><a class="dropdown-item custom-dropdown-item" href="https://www.greenairiva.com.tr/tr/about/#contribution">Sosyal ve Çevresel Katkı</a></li>
                     </ul>
                   </li>
-                  <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">Contact</a></li>
+                  <li class="nav-item"><a class="nav-link" id="scrollToContact" href="#contact">İletişim</a></li>
                   <li class="nav-item lang-switch tr-switch">TR</li>
                   <li class="nav-item lang-switch en-switch">EN</li>
                 </ul>
             </div>
         </div>
-    </nav>
-<!-- Masthead -->
-<!--
-        <header class="masthead">
-    <div class="container">
-        <div class="masthead-heading">Rise<br>for a</div>
-        <div class="masthead-subheading-script">Cleaner</div>
-        <div class="masthead-heading">Planet</div>
-        <div class="masthead-btn-row">
-            <a class="btn btn-primary btn-xl text-uppercase" href="https://www.greenairiva.com.tr/about/#about">Discover Our Solutions</a>
+      </nav>
+    </header>
+    <div class="article-wrapper container">
+      <section class="hero-card">
+        <div class="hero-meta">
+          <h1 class="post-title"></h1>
+          <p class="post-byline">Yazan <span class="post-author"></span> · <time class="post-date"></time></p>
         </div>
-    </div>
-</header>
--->
-        <header class="masthead article-masthead" id="article-masthead">
-    <div class="container">
-        <div class="article-masthead-info">
-            <span id="article-category-head" class="badge bg-success me-2"></span>
-            <span id="article-date-head" class="text-light small"></span>
-            <h1 id="article-title-head" class="article-masthead-title text-white mt-2"></h1>
-        </div>
-    </div>
-</header>
+        <figure class="hero-cover">
+          <img class="hero-img" id="article-hero-img" alt="">
+        </figure>
+        <div class="post-abstract callout"></div>
+      </section>
 
-<!-- Article Main -->
-<main class="container my-5" id="article-main">
-  <div class="row justify-content-center">
-    <div class="col-lg-10 col-xl-8">
-      <article class="blog-single border-0 shadow-none">
-        <img id="article-image" src="" alt="" class="img-fluid rounded mb-3 article-image">
-        <div class="mb-2">
-          <span id="article-category" class="badge bg-success me-2"></span>
-          <span id="article-date" class="text-muted small"></span>
-        </div>
-        <h1 id="article-title" class="blog-title"></h1>
-        <div id="article-summary" class="lead text-muted mb-3"></div>
-        <div id="article-content" class="blog-content"></div>
-      </article>
-      <div id="article-notfound" class="alert alert-warning mt-4 article-notfound">Article not found.</div>
+      <nav aria-label="Breadcrumb">
+        <ol class="breadcrumb">
+          <!-- JS dolduracak: Anasayfa › Blog › {title} -->
+        </ol>
+      </nav>
+
+      <div id="article-notfound" class="alert alert-warning article-notfound" hidden>Yazı bulunamadı.</div>
+
+      <main class="article-layout">
+        <div class="left-spacer"></div>
+        <article class="article-content" id="article-content"><!-- md’den üretilen html burada --></article>
+        <aside class="toc-sidebar" aria-label="İçindekiler">
+          <div class="toc-header">İçindekiler</div>
+          <nav id="js-toc" class="toc"></nav>
+        </aside>
+      </main>
+
+      <section class="related-posts" id="related-posts">
+        <h2>Okumaya devam et</h2>
+        <div class="card-grid" id="related-posts-grid"></div>
+      </section>
+
+      <section class="post-tags" id="post-tags" aria-label="Etiketler"></section>
     </div>
-  </div>
-</main>
+
+    <script type="application/ld+json" id="breadcrumb-jsonld"><!-- JS dolduracak --></script>
 
 
    <!-- Contact-->
 <section class="page-section" id="contact">
   <div class="container">
     <div class="text-center">
-                <h2 class="section-heading text-uppercase">İletişim</h2>
-                <h3 class="section-subheading text-muted">Görüşlerinizi bizimle paylaşmaktan çekinmeyin.</h3>
+      <h2 class="section-heading text-uppercase">İletişim</h2>
+      <h3 class="section-subheading text-muted">Görüşlerinizi bizimle paylaşmaktan çekinmeyin.</h3>
     </div>
 
     <form action="https://formspree.io/f/mblyywgr" method="POST">
@@ -158,74 +157,23 @@
                 </a>
             </div>
             <div class="col-lg-4 text-lg-end text-center">
-                <a class="link-dark text-decoration-none me-3" href="/privacy/">Privacy Policy</a>
-                <a class="link-dark text-decoration-none" href="/terms/">Terms of Use</a>
+                <a class="link-dark text-decoration-none me-3" href="/privacy/">Gizlilik Politikası</a>
+                <a class="link-dark text-decoration-none" href="/terms/">Kullanım Şartları</a>
             </div>
         </div>
     </div>
 </footer>
-		<!-- Scripts -->
+                <!-- Scripts -->
 
-			<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
-			<script src="https://kit.fontawesome.com/yourfontawesomekit.js" crossorigin="anonymous"></script>
-			<script src="../js/scripts.js"></script>
-	<script>
-document.addEventListener('DOMContentLoaded', function () {
-  // 1. URL'den slug/id oku (?slug=2025-07-14-sera-gazlari gibi)
-  const params = new URLSearchParams(window.location.search);
-  const slug = params.get('slug');
+                        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
+                        <script src="https://kit.fontawesome.com/yourfontawesomekit.js" crossorigin="anonymous"></script>
+                        <script src="../js/scripts.js"></script>
 
-  // 2. posts.json'dan ilgili yazıyı bul
-  fetch('posts.json')
-    .then(response => response.json())
-    .then(posts => {
-      const post = posts.find(p => p.slug === slug);
-      if (!post) {
-        document.getElementById('article-notfound').style.display = 'block';
-        document.querySelector('.blog-single').style.display = 'none';
-        return;
-      }
-
-      if (post.image) {
-        document.getElementById('article-masthead').style.backgroundImage = `url('${post.image}')`;
-        document.getElementById('article-masthead').style.backgroundColor = "#212529";
-      }
-      document.getElementById('article-category-head').textContent = post.category || '';
-      document.getElementById('article-date-head').textContent = post.date ? new Date(post.date).toLocaleDateString('tr-TR', { day: '2-digit', month: 'long', year: 'numeric' }) : '';
-      document.getElementById('article-title-head').textContent = post.title || '';
-     
-      // 3. Alanları doldur
-//      if (post.image) {
-//        const img = document.getElementById('article-image');
-//        img.src = post.image;
-//        img.alt = post.title;
-//        img.style.display = 'block';
-//      }
-//      document.getElementById('article-category').textContent = post.category || '';
-//      document.getElementById('article-date').textContent = post.date ? new Date(post.date).toLocaleDateString('tr-TR', { day: '2-digit', month: 'long', year: 'numeric' }) : '';
-//      document.getElementById('article-title').textContent = post.title || '';
-//      document.getElementById('article-summary').textContent = post.summary || '';
-      // 4. İçerik dosyasını fetch et (ör: /posts/2025-07-14-sera-gazlari.md)
-      if (post.url) {
-        fetch(post.url)
-          .then(res => res.text())
-          .then(md => {
-            // Eğer markdown ise marked.js ile parse et, yoksa direkt göster
-            if (window.marked) {
-              document.getElementById('article-content').innerHTML = marked.parse(md);
-            } else {
-              document.getElementById('article-content').textContent = md;
-            }
-          });
-      }
-    });
-});
-</script>
 <!-- Optional: Markdown desteği için -->
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 
-	    <script src="../js/scripts.js"></script>
-    <script>
+
+        <script>
     document.addEventListener('DOMContentLoaded', function () {
       const params = new URLSearchParams(window.location.search);
       const slug = params.get('slug');
@@ -236,5 +184,5 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     </script>
 
-	</body>
+        </body>
 </html>

--- a/tr/posts.json
+++ b/tr/posts.json
@@ -3,10 +3,15 @@
     "slug": "2025-07-14-social-cost-ghg",
     "title": "Sera Gazlarının Sosyal Maliyeti ve Türkiye İçin Önemi: EPA SC-GHG Raporu Çerçevesinde Detaylı Bir Analiz",
     "date": "2025-07-14",
-    "category": ["EPA","Greenhouse Gases"],
+    "category": ["EPA", "Greenhouse Gases"],
     "summary": "Sera gazlarının sosyal maliyeti, atmosfere salınan gazların gelecekte yaratacağı çevresel ve ekonomik zararların bugünkü parasal değeridir. Bu çalışma, EPA'nın 2023 SC-GHG raporunu temel alarak, Türkiye özelinde Ankara ili için bir hesaplama sunmakta ve GreenAiriva’nın yenilikçi çözümleriyle sosyal maliyet azaltımına katkılarını analiz etmektedir.",
+    "abstract": "Sera gazlarının sosyal maliyeti, atmosfere salınan gazların gelecekte yaratacağı çevresel ve ekonomik zararların bugünkü parasal değeridir. Bu çalışma, EPA'nın 2023 SC-GHG raporunu temel alarak, Türkiye özelinde Ankara ili için bir hesaplama sunmakta ve GreenAiriva’nın yenilikçi çözümleriyle sosyal maliyet azaltımına katkılarını analiz etmektedir.",
     "image": "../assets/img/blog/1.jpg",
-    "url": "posts/2025-07-15-social-cost.md"
+    "cover": "../assets/img/blog/1.jpg",
+    "author": "GreenAiriva Araştırma Ekibi",
+    "tags": ["EPA", "Sosyal Maliyet", "İklim Politikası"],
+    "url": "article.html?slug=2025-07-14-social-cost-ghg",
+    "content": "posts/2025-07-15-social-cost.md"
   },
   {
     "slug": "2025-07-10-hava-kalitesi-greenairiva",
@@ -14,8 +19,13 @@
     "date": "2025-07-15",
     "category": "Greenhouse Gases",
     "summary": "Bu yazıda, hava kalitesi ölçüm metodolojileri ve GreenAiriva'nın yenilikçi teknolojileri anlatılıyor.",
+    "abstract": "Bu yazıda, hava kalitesi ölçüm metodolojileri ve GreenAiriva'nın yenilikçi teknolojileri anlatılıyor.",
     "image": "../assets/img/blog/2.jpg",
-    "url": "posts/2025-07-14-sera-gazlari.md"
+    "cover": "../assets/img/blog/2.jpg",
+    "author": "GreenAiriva Veri Ekibi",
+    "tags": ["Hava Kalitesi", "İzleme", "GreenAiriva"],
+    "url": "article.html?slug=2025-07-10-hava-kalitesi-greenairiva",
+    "content": "posts/2025-07-14-sera-gazlari.md"
   },
   {
     "slug": "2025-07-16-Sehir-ici-Hava-Filtreleme",
@@ -23,7 +33,12 @@
     "date": "2025-07-16",
     "category": ["urban air cleaning", "active air filters", "CO2 capture", "green tech"],
     "summary": "Kentlerde PM, NOx ve sera gazları kaynaklı hava kirliliği sağlık ve iklimi tehdit ediyor. Yosun filtreleri, iyonizasyon kuleleri ve DAC gibi çözümler sınırlı kalıyor. GreenAiriva, çok katmanlı adsorban teknolojisi, gerçek zamanlı veri analizi ve güneş enerjisiyle çalışarak farklı kirleticileri hedef alıyor. Bu sayede mevcut teknolojilerdeki boşlukları dolduruyor ve kentsel hava temizliğinde yenilikçi, sürdürülebilir bir çözüm sunuyor.",
+    "abstract": "Kentlerde PM, NOx ve sera gazları kaynaklı hava kirliliği sağlık ve iklimi tehdit ediyor. Yosun filtreleri, iyonizasyon kuleleri ve DAC gibi çözümler sınırlı kalıyor. GreenAiriva, çok katmanlı adsorban teknolojisi, gerçek zamanlı veri analizi ve güneş enerjisiyle çalışarak farklı kirleticileri hedef alıyor. Bu sayede mevcut teknolojilerdeki boşlukları dolduruyor ve kentsel hava temizliğinde yenilikçi, sürdürülebilir bir çözüm sunuyor.",
     "image": "../assets/img/blog/2025-07-16-Sehir-ici-Hava-Filtreleme/2025-07-16-Sehir-ici-Hava-Filtreleme.png",
-    "url": "posts/2025-07-16-Sehir-ici-Hava-Filtreleme.md"
+    "cover": "../assets/img/blog/2025-07-16-Sehir-ici-Hava-Filtreleme/2025-07-16-Sehir-ici-Hava-Filtreleme.png",
+    "author": "GreenAiriva Ar-Ge Ekibi",
+    "tags": ["Kentsel Hava", "CO2 Yakalama", "Yeşil Teknoloji"],
+    "url": "article.html?slug=2025-07-16-Sehir-ici-Hava-Filtreleme",
+    "content": "posts/2025-07-16-Sehir-ici-Hava-Filtreleme.md"
   }
 ]


### PR DESCRIPTION
## Summary
- align `tr/article.html` with the fixed hero media box layout, localized copy, and language toggle behaviour used on the English page
- teach the shared article enhancements script to derive language-specific labels, links, and dates for breadcrumbs, bylines, tag chips, and related cards
- expand `tr/posts.json` entries with cover, abstract, author, and tag metadata plus markdown paths so the Turkish article view renders hero media, summaries, and tag chips correctly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb1f56c258832ebcde999b2f712f3a