### PR TITLE
Index sayfalarının light tema + modern arayüz revizyonu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -92,8 +92,8 @@
   --bs-body-font-size: 1rem;
   --bs-body-font-weight: 400;
   --bs-body-line-height: 1.5;
-  --bs-body-color: #212529;
-  --bs-body-bg: #fff;
+  --bs-body-color: #232323;
+  --bs-body-bg: #f7f8fa;
   --bs-border-width: 1px;
   --bs-border-style: solid;
   --bs-border-color: #dee2e6;
@@ -1580,65 +1580,70 @@ p {
 #mainNav {
   padding-top: 1rem;
   padding-bottom: 1rem;
-  background-color: #212529;
+  background-color: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, padding 0.3s ease;
 }
 #mainNav .navbar-toggler {
-  padding: 0.75rem;
+  padding: 0.65rem 0.9rem;
   font-size: 0.75rem;
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   text-transform: uppercase;
   font-weight: 700;
+  color: #232323;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 999px;
 }
 #mainNav .navbar-brand {
-  color: #ffc800;
+  color: #232323;
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-weight: 700;
-  letter-spacing: 0.0625em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 #mainNav .navbar-brand img {
-  height: 1.5rem;
+  height: 1.6rem;
+  transition: height 0.3s ease;
 }
 #mainNav .navbar-nav .nav-item .nav-link {
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-size: 0.95rem;
-  color: #fff;
-  letter-spacing: 0.0625em;
+  color: #232323;
+  letter-spacing: 0.06em;
+  padding: 0.75rem 0.9rem;
+  transition: color 0.25s ease;
 }
-#mainNav .navbar-nav .nav-item .nav-link.active, #mainNav .navbar-nav .nav-item .nav-link:hover {
-  color: #ffc800;
+#mainNav .navbar-nav .nav-item .nav-link.active,
+#mainNav .navbar-nav .nav-item .nav-link:hover {
+  color: #f47a29;
 }
 
 @media (min-width: 992px) {
   #mainNav {
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
-    border: none;
-    background-color: transparent;
-    transition: padding-top 0.3s ease-in-out, padding-bottom 0.3s ease-in-out;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
   }
   #mainNav .navbar-brand {
     font-size: 1.5em;
-    transition: font-size 0.3s ease-in-out;
   }
   #mainNav .navbar-brand img {
     height: 2rem;
-    transition: height 0.3s ease-in-out;
   }
   #mainNav.navbar-shrink {
-    padding-top: 1rem;
-    padding-bottom: 1rem;
-    background-color: #212529;
+    padding-top: 0.85rem;
+    padding-bottom: 0.85rem;
+    border-bottom-color: transparent;
+    box-shadow: 0 14px 40px rgba(15, 23, 42, 0.12);
   }
   #mainNav.navbar-shrink .navbar-brand {
-    font-size: 1.25em;
+    font-size: 1.3em;
   }
-  #mainNav.navbar-shrink .navbar-brand svg,
   #mainNav.navbar-shrink .navbar-brand img {
-    height: 1.5rem;
+    height: 1.6rem;
   }
   #mainNav .navbar-nav .nav-item {
-    margin-right: 1rem;
+    margin-right: 0.35rem;
   }
   #mainNav .navbar-nav .nav-item:last-child {
     margin-right: 0;
@@ -1647,116 +1652,74 @@ p {
 /*Masthead*/
 /* 06.2 Masthead */
 header.masthead {
-  min-height: 100vh;
+  min-height: 70vh;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  color: #fff;
-  background-image: url("../assets/img/header-bg.jpg");
-  background-repeat: no-repeat;
-  background-position: center center;
-  background-size: cover;
   text-align: center;
-  padding: 90px 0 48px 0;
-  box-sizing: border-box;
+  padding: 140px 0 120px;
+  background: linear-gradient(135deg, #ffffff 0%, #f0f4ff 100%);
+  color: #101828;
 }
 header.masthead .container {
-  display: block;
-  text-align: left;
+  max-width: 960px;
   padding: 0 1.5rem;
-}
-.masthead-heading {
-  font-size: 3.25rem;
-  font-weight: 700;
-  margin: 2rem 0;
-  font-family: "Montserrat", sans-serif;
-  line-height: 1.1;
-}
-.masthead-subheading-script {
-  font-size: 5rem;
-  font-weight: 700;
-  line-height: 4rem;
-  margin: 0;
-  color: #f49a27;
-  font-family: 'The Youngest Script', cursive;
-}
-.masthead-btn-row {
   display: flex;
-  justify-content: flex-end;
-  margin-top: -100px;
-  margin-right: 40px;
-  gap: 10px;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
 }
-.masthead .btn-xl {
-  width: auto;
-  min-width: 150px;
-  max-width: 300px;
-  padding: 1em 2em;
-  font-size: 1.08rem;
-  font-weight: 700;
-  border-radius: 1.4em;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.09);
+.masthead-title {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 800;
+  font-size: clamp(2.8rem, 5vw, 4.2rem);
+  line-height: 1.1;
+  margin: 0;
+  color: #101828;
+}
+.masthead-tagline {
+  font-family: "Montserrat", sans-serif;
+  font-weight: 500;
+  font-size: clamp(1.1rem, 2vw, 1.5rem);
+  color: #475467;
+  max-width: 640px;
+  margin: 0;
 }
 
-/* ----------- Responsive ------------ */
 @media (max-width: 991.98px) {
   header.masthead {
-    min-height: 48vh;
-    padding-top: 64px;
-    padding-bottom: 24px;
+    min-height: 60vh;
+    padding: 120px 0 96px;
+    text-align: left;
   }
-  .masthead-btn-row {
-    margin-top: 2rem;
-    margin-right: 0;
-    justify-content: right;
+  header.masthead .container {
+    align-items: flex-start;
+    text-align: left;
+    padding: 0 1.25rem;
+    gap: 1.25rem;
   }
-  .masthead-heading {
-    font-size: 2.2rem;
+  .masthead-title {
+    font-size: clamp(2.2rem, 7vw, 3.4rem);
   }
-  .masthead-subheading-script {
-    font-size: 3rem;
-    line-height: 1rem;
+  .masthead-tagline {
+    font-size: clamp(1rem, 2.8vw, 1.25rem);
+    max-width: 480px;
   }
 }
+
 @media (max-width: 575.98px) {
   header.masthead {
     min-height: 100vh;
-    padding-top: 18vw;
-    padding-bottom: 16px;
-    text-align: left;
-    align-items: flex-start;
+    padding: 108px 1rem 72px;
   }
   header.masthead .container {
-    padding-left: 0.7rem;
-    padding-right: 0.7rem;
-    text-align: left;
+    padding: 0;
   }
-  .masthead-heading {
-    font-size: 2.5rem;
-    margin: 0.1em 0;
-    line-height: 1.25;
-    padding-left: 1rem;
+  .masthead-title {
+    font-size: clamp(2rem, 9vw, 2.6rem);
   }
-  .masthead-subheading-script {
-    font-size: 3.62rem;
-    margin: 0.0em 0;
-    line-height: 1.15;
-    padding-left: 1rem;
-  }
-  .masthead-btn-row {
-    margin-top: 5.1rem;
-    width: 80%;
-    justify-content: flex-start;
-    gap: 10px
-  }
-  .masthead-btn-row .btn-xl {
-    width: 100%;
-    padding: 0.7em 0;
+  .masthead-tagline {
     font-size: 1rem;
-    border-radius: 1.3em;
-    min-width: 0;
-    max-width: 97vw;
   }
 }
 
@@ -1925,32 +1888,62 @@ section#contact .section-heading {
   text-align: center;
   font-size: 0.9rem;
   font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  background-color: #ffffff;
+  border-top: 1px solid #e4e8f1;
+  color: #475467;
+}
+.footer a {
+  color: #232323;
+  transition: color 0.2s ease;
+}
+.footer a:hover {
+  color: #f47a29;
+}
+.footer .btn-social {
+  background-color: #eef2f8;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  color: #1f2937;
+}
+.footer .btn-social:hover {
+  background-color: #e2e8f0;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.15);
+}
+.footer .btn-social img,
+.footer-social-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  filter: none;
 }
 /* ==== Custom ABOUT Dropdown Styles (GreenAiriva) ==== */
 .custom-dropdown-menu {
-    background-color: #111  ;
-    min-width: 180px;
-    border-radius: 0 0 12px 12px;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-    padding: 0.5rem 0;
-    margin-top: 5px;
+    background-color: #ffffff;
+    min-width: 200px;
+    border-radius: 14px;
+    box-shadow: 0 22px 45px rgba(15, 23, 42, 0.12);
+    padding: 0.65rem 0;
+    margin-top: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .custom-dropdown-item {
-    color: #fff  ;
+    color: #1f2937;
     font-family: 'Montserrat', sans-serif;
-    font-size: 0.95rem  ;
-    padding: 8px 20px;
+    font-size: 0.95rem;
+    padding: 10px 20px;
     font-weight: 500;
     transition: background 0.2s, color 0.2s;
 }
 
 .custom-dropdown-item:hover, .custom-dropdown-item:focus {
-    background-color: #f47a29  ;
-    color: #fff  ;
+    background-color: #f5f7fb;
+    color: #f47a29;
 }
 
-.navbar-dark .navbar-nav .nav-link.dropdown-toggle::after {
+.navbar-light .navbar-nav .nav-link.dropdown-toggle::after {
     color: #f47a29;
 }
 /* ==== END Custom ABOUT Dropdown Styles ==== */
@@ -2173,61 +2166,149 @@ h1, h2, h3, h4, h5 {
 /* =========================================================
    07. Print
    ========================================================= */
-/* === GreenAiriva Blog Board (Dark) === */
-.ga-board { background:#0f1115; padding:2.5rem 0 3.5rem; }
-.ga-title { color:#fff; font-size:clamp(1.4rem,2.5vw,1.8rem); font-weight:800; margin:0 0 1rem; }
-.ga-toolbar { display:flex; align-items:center; justify-content:space-between; gap:1rem; margin-bottom:1rem; }
-.ga-tags { display:flex; gap:.5rem; overflow:auto; padding-bottom:.25rem; scrollbar-width:none; }
-.ga-tags::-webkit-scrollbar{ display:none; }
-
-.ga-pill {
-  background:#151923; color:#cbd5e1; border:1px solid #1f2430;
-  padding:.45rem .85rem; border-radius:1rem; font-weight:600; white-space:nowrap;
+/* === GreenAiriva Blog Board (Light) === */
+.ga-board {
+  background: transparent;
+  padding: 3.5rem 0 4.5rem;
 }
-.ga-pill:hover { background:#1a2030; color:#e5e7eb; }
-.ga-pill.active { background:#2a3347; color:#fff; border-color:#2f3a51; }
+.ga-search-wrap {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto 2.5rem;
+}
+.ga-search {
+  width: 100%;
+  background: #ffffff;
+  color: #232323;
+  border: 1px solid #dce3ed;
+  padding: 0.9rem 1.2rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.ga-search:focus {
+  outline: none;
+  border-color: #f47a29;
+  box-shadow: 0 24px 55px rgba(244, 122, 41, 0.18);
+}
+.ga-search::placeholder {
+  color: #6b7280;
+}
 
-.ga-search { background:#0f131c; color:#e5e7eb; border:1px solid #1f2430; padding:.55rem .9rem; border-radius:.6rem; min-width:220px; }
-.ga-search::placeholder{ color:#93a1b5; }
+.ga-grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+@media (min-width: 768px) {
+  .ga-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (min-width: 992px) {
+  .ga-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
 
-.ga-grid { display:grid; grid-template-columns:repeat(1,minmax(0,1fr)); gap:1rem; }
-@media (min-width:768px){ .ga-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
-@media (min-width:1200px){ .ga-grid{ grid-template-columns:repeat(3,minmax(0,1fr)); } }
-.ga-empty{ color:#9fb0c9; text-align:center; padding:2.4rem 0; font-size:.95rem; }
+.ga-empty {
+  color: #6b7280;
+  text-align: center;
+  padding: 2.4rem 0;
+  font-size: 0.95rem;
+}
 
 .ga-card {
-  background:#11151e; border:1px solid #1a2030; border-radius:14px;
-  box-shadow:0 6px 20px rgba(0,0,0,.25); overflow:hidden; display:flex; flex-direction:column;
-  transition:transform .18s ease, box-shadow .18s ease, border-color .18s;
+  background: #ffffff;
+  border: 1px solid #e4e9f4;
+  border-radius: 14px;
+  box-shadow: 0 6px 24px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s;
 }
-.ga-card:hover{ transform:translateY(-2px); box-shadow:0 16px 40px rgba(0,0,0,.35); border-color:#273149; }
-
-.ga-thumb{ display:block; aspect-ratio:16/9; background:#0b0d12; }
-.ga-thumb img{ width:100%; height:100%; object-fit:cover; display:block; }
-
-.ga-body{ padding:.9rem .95rem .25rem; }
-.ga-h3{ margin:0 0 .35rem; font-size:1rem; line-height:1.35; }
-.ga-h3 a{ color:#eef2ff; text-decoration:none; }
-.ga-h3 a:hover{ text-decoration:underline; }
-.ga-excerpt{ color:#98a6be; font-size:.92rem; line-height:1.55; margin:0; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
-
-.ga-meta{
-  display:flex; align-items:center; justify-content:space-between;
-  padding:.6rem .8rem .8rem; gap:.5rem; border-top:1px solid #1a2030; color:#9fb0c9;
+.ga-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.16);
+  border-color: #d0d7e4;
 }
-.ga-meta-left{ display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; }
-.ga-badge{ background:#172033; color:#cbd5e1; border:1px solid #24314a; font-size:.75rem; padding:.15rem .5rem; border-radius:.5rem;}
-.ga-dot{ width:4px; height:4px; background:#3b4457; border-radius:999px; display:inline-block; margin:0 .15rem; }
-.ga-sep{ opacity:.6; }
-.ga-read{ font-size:.82rem; }
 
-.ga-meta-right{ display:flex; align-items:center; gap:.55rem; }
-.ga-stat{ display:inline-flex; align-items:center; gap:.35rem; font-size:.82rem; color:#9fb0c9; }
-.ga-stat svg{ width:16px; height:16px; opacity:.85; }
+.ga-thumb {
+  display: block;
+  aspect-ratio: 16 / 9;
+  background: #f1f5f9;
+}
+.ga-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
 
-.ga-pager{ display:flex; justify-content:center; gap:.4rem; margin-top:1rem; }
-.ga-pager .pg{ background:#151923; color:#cfd8ea; border:1px solid #222a3a; padding:.5rem .75rem; border-radius:.5rem; }
-.ga-pager .pg.active, .ga-pager .pg:hover{ background:#2a3347; color:#fff; border-color:#2f3a51; }
+.ga-body {
+  padding: 1.1rem 1.25rem 0.55rem;
+}
+.ga-h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.02rem;
+  line-height: 1.4;
+}
+.ga-h3 a {
+  color: #111827;
+  text-decoration: none;
+}
+.ga-h3 a:hover {
+  color: #f47a29;
+}
+.ga-excerpt {
+  color: #4b5563;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.ga-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.25rem 1.1rem;
+  border-top: 1px solid #edf1f7;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+.ga-meta time {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.ga-pager {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+.ga-pager .pg {
+  background: #ffffff;
+  color: #475569;
+  border: 1px solid #dce3ed;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.ga-pager .pg.active,
+.ga-pager .pg:hover {
+  background: #f47a29;
+  color: #ffffff;
+  border-color: #f47a29;
+  box-shadow: 0 14px 36px rgba(244, 122, 41, 0.2);
+}
 
 /* Article layout enhancements */
 .article-wrapper {

--- a/index.html
+++ b/index.html
@@ -14,21 +14,23 @@
     <style>
         .lang-switch {
             display: inline-block;
-            padding: 5px 10px;
+            padding: 6px 14px;
             margin-left: 10px;
             cursor: pointer;
-            transition: background-color 0.3s;
+            transition: background-color 0.3s, color 0.3s;
             font-family: 'Montserrat', sans-serif;
-            color: #fff;
+            color: #232323;
+            border-radius: 999px;
         }
         .lang-switch:hover {
-            background-color: #f47a29;
+            background-color: rgba(35, 35, 35, 0.08);
+            color: #101828;
         }
     </style>
 </head>
 <body id="page-top">
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+    <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
         <div class="container">
             <a class="navbar-brand" href="https://www.greenairiva.com.tr/"><img src="assets/img/navbar-logo.svg" alt="GreenAiriva logo" /></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
@@ -64,26 +66,18 @@
         </div>
     </nav>
 <!-- Masthead -->
-<header class="masthead" style="height:60vh; min-height:350px; display:flex; align-items:center;">
+<header class="masthead">
     <div class="container">
-        <div class="masthead-heading">Rise<br>for a</div>
-        <div class="masthead-subheading-script">Cleaner</div>
-        <div class="masthead-heading">Planet</div>
-        <div class="masthead-btn-row">
-            <a class="btn btn-primary btn-xl text-uppercase" href="https://www.greenairiva.com.tr/about/#about">Discover Our Solutions</a>
-        </div>
+        <h1 class="masthead-title">Rise for a Cleaner Planet</h1>
+        <p class="masthead-tagline">Stories, updates, and ideas from the GreenAiriva team on making cleaner urban air a reality.</p>
     </div>
 </header>
 
     <!-- GreenAiriva Blog Board -->
     <section id="ga-board" class="ga-board">
       <div class="container">
-        <h2 class="ga-title">Latest Insights</h2>
-        <div class="ga-toolbar">
-          <div class="ga-tags" id="gaTagBar"></div>
-          <div class="ga-actions">
-            <input id="gaSearch" class="ga-search" placeholder="Search posts…" />
-          </div>
+        <div class="ga-search-wrap">
+          <input id="gaSearch" class="ga-search" placeholder="Search insights…" />
         </div>
         <div id="gaGrid" class="ga-grid"></div>
         <div class="ga-pager" id="gaPager"></div>
@@ -131,14 +125,14 @@
                 Copyright &copy; GreenAiriva 2025
             </div>
             <div class="col-lg-4 my-3 my-lg-0 text-center">
-                <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="X">
-                    <img src="assets/img/logos/icons8-x-500.svg" alt="X" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                <a class="btn btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="X">
+                    <img src="assets/img/logos/icons8-x-500.svg" alt="X" class="footer-social-icon" />
                 </a>
-                <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="Instagram">
-                    <img src="assets/img/logos/icons8-instagram-500.svg" alt="Instagram" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                <a class="btn btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="Instagram">
+                    <img src="assets/img/logos/icons8-instagram-500.svg" alt="Instagram" class="footer-social-icon" />
                 </a>
-                <a class="btn btn-dark btn-social mx-2" href="https://www.linkedin.com/company/greenairiva/" aria-label="LinkedIn">
-                    <img src="assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                <a class="btn btn-social mx-2" href="https://www.linkedin.com/company/greenairiva/" aria-label="LinkedIn">
+                    <img src="assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" class="footer-social-icon" />
                 </a>
             </div>
             <div class="col-lg-4 text-lg-end text-center">

--- a/tr/index.html
+++ b/tr/index.html
@@ -14,21 +14,23 @@
     <style>
         .lang-switch {
             display: inline-block;
-            padding: 5px 10px;
+            padding: 6px 14px;
             margin-left: 10px;
             cursor: pointer;
-            transition: background-color 0.3s;
+            transition: background-color 0.3s, color 0.3s;
             font-family: 'Montserrat', sans-serif;
-            color: #fff;
+            color: #232323;
+            border-radius: 999px;
         }
         .lang-switch:hover {
-            background-color: #f47a29;
+            background-color: rgba(35, 35, 35, 0.08);
+            color: #101828;
         }
     </style>
 </head>
 <body id="page-top">
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+    <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
         <div class="container">
             <a class="navbar-brand" href="https://www.greenairiva.com.tr/tr/"><img src="../assets/img/navbar-logo.svg" alt="GreenAiriva logo" /></a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
@@ -64,26 +66,18 @@
         </div>
     </nav>
 <!-- Masthead -->
-<header class="masthead" style="height:60vh; min-height:350px; display:flex; align-items:center;">
+<header class="masthead">
     <div class="container">
-        <div class="masthead-heading">Daha</div>
-        <div class="masthead-subheading-script">Temiz</div>
-        <div class="masthead-heading">Bir<br>Dünya</div>
-        <div class="masthead-btn-row">
-            <a class="btn btn-primary btn-xl text-uppercase" href="https://www.greenairiva.com.tr/about/#about">Çözümlerimizi Keşfedin</a>
-        </div>
+        <h1 class="masthead-title">Daha Temiz Bir Dünya İçin Birlikte</h1>
+        <p class="masthead-tagline">Şehir havasını dönüştürmeye dair hikayeler, gelişmeler ve GreenAiriva ekibinden içgörüler.</p>
     </div>
 </header>
 
     <!-- GreenAiriva Blog Board -->
     <section id="ga-board" class="ga-board">
       <div class="container">
-        <h2 class="ga-title">Son Yazılar</h2>
-        <div class="ga-toolbar">
-          <div class="ga-tags" id="gaTagBar"></div>
-          <div class="ga-actions">
-            <input id="gaSearch" class="ga-search" placeholder="Yazılarda ara…" />
-          </div>
+        <div class="ga-search-wrap">
+          <input id="gaSearch" class="ga-search" placeholder="İçgörülerde ara…" />
         </div>
         <div id="gaGrid" class="ga-grid"></div>
         <div class="ga-pager" id="gaPager"></div>
@@ -131,14 +125,14 @@
                 Copyright &copy; GreenAiriva 2025
             </div>
             <div class="col-lg-4 my-3 my-lg-0 text-center">
-                <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="X">
-                    <img src="../assets/img/logos/icons8-x-500.svg" alt="X" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                <a class="btn btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="X">
+                    <img src="../assets/img/logos/icons8-x-500.svg" alt="X" class="footer-social-icon" />
                 </a>
-                <a class="btn btn-dark btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="Instagram">
-                    <img src="../assets/img/logos/icons8-instagram-500.svg" alt="Instagram" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                <a class="btn btn-social mx-2" href="https://www.instagram.com/greenairiva/" aria-label="Instagram">
+                    <img src="../assets/img/logos/icons8-instagram-500.svg" alt="Instagram" class="footer-social-icon" />
                 </a>
-                <a class="btn btn-dark btn-social mx-2" href="https://www.linkedin.com/company/greenairiva/" aria-label="LinkedIn">
-                    <img src="../assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" style="width:24px; height:24px; object-fit:contain; filter:invert(1);" />
+                <a class="btn btn-social mx-2" href="https://www.linkedin.com/company/greenairiva/" aria-label="LinkedIn">
+                    <img src="../assets/img/logos/icons8-linkedin-500.svg" alt="LinkedIn" class="footer-social-icon" />
                 </a>
             </div>
             <div class="col-lg-4 text-lg-end text-center">


### PR DESCRIPTION
## Summary
- modernize the English and Turkish landing pages with a centered hero, search-focused blog board, and refreshed light footer styles
- refresh the global stylesheet for a bright palette, new responsive masthead rules, updated navigation, and card/grid styling that matches the light theme
- simplify the blog board script to drop tag controls while keeping search-driven filtering and date-only metadata

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb4d5b9b28832ea515b6908d15425d