### PR TITLE
Fix article related post cards to match index style

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2481,30 +2481,83 @@ h1, h2, h3, h4, h5 {
 }
 
 .post-card {
-  border-radius: 0.75rem;
+  background: #ffffff;
+  border: 1px solid #e4e9f4;
+  border-radius: 14px;
+  box-shadow: 0 6px 24px rgba(15, 23, 42, 0.08);
   overflow: hidden;
-  background: var(--surface, rgba(255, 255, 255, 0.04));
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.post-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.16);
+  border-color: #d0d7e4;
+}
+
+.post-card .card-cover-link {
+  display: block;
+  aspect-ratio: 16 / 9;
+  background: #f1f5f9;
 }
 
 .post-card .card-cover {
   width: 100%;
-  height: 160px;
+  height: 100%;
   object-fit: cover;
   display: block;
 }
 
 .post-card .card-body {
-  padding: 0.75rem 1rem;
+  padding: 1.1rem 1.25rem 0.55rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.post-card .card-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.02rem;
+  line-height: 1.4;
+}
+
+.post-card .card-title a {
+  color: #111827;
+  text-decoration: none;
+}
+
+.post-card .card-title a:hover {
+  color: #f47a29;
 }
 
 .post-card .card-excerpt {
+  color: #4b5563;
   font-size: 0.95rem;
-  opacity: 0.85;
+  line-height: 1.6;
+  margin: 0;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  flex: 1;
+}
+
+.post-card .card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.25rem 1.1rem;
+  border-top: 1px solid #edf1f7;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.post-card .card-meta time {
+  font-weight: 600;
+  color: #1f2937;
 }
 
 .post-tags {

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -917,18 +917,19 @@ function createRelatedCard(post) {
     ? post.dateObj.toLocaleDateString(articleLocale, { year: 'numeric', month: 'short', day: 'numeric' })
     : '';
   const dateISO = post.dateISO || '';
+  const datetimeAttr = dateISO ? ` datetime="${dateISO}"` : '';
   const cover = post.cover || ARTICLE_FALLBACK_COVER;
   const abstract = post.abstract || post.summary || '';
   return `
   <article class="post-card">
-    <a href="${post.url}" class="card-link">
+    <a class="card-cover-link" href="${post.url}">
       <img class="card-cover" src="${cover}" alt="${post.title}" loading="lazy">
-      <div class="card-body">
-        <h3 class="card-title">${post.title}</h3>
-        <p class="card-excerpt">${abstract}</p>
-        <div class="card-meta"><time datetime="${dateISO}">${dateText}</time></div>
-      </div>
     </a>
+    <div class="card-body">
+      <h3 class="card-title"><a href="${post.url}">${post.title}</a></h3>
+      <p class="card-excerpt">${abstract}</p>
+    </div>
+    <div class="card-meta"><time${datetimeAttr}>${dateText}</time></div>
   </article>
   `;
 }


### PR DESCRIPTION
## Summary
- adjust related post card markup on article pages so only the image and title are linked and the layout mirrors the blog index cards
- refresh the Keep reading card styles to reuse the index look without touching the global link color rules

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cff6a61174832e920ed9a53d08500c