### PR TITLE
Restore masthead background image

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1658,7 +1658,10 @@ header.masthead {
   align-items: center;
   text-align: center;
   padding: 140px 0 120px;
-  background: linear-gradient(135deg, #ffffff 0%, #f0f4ff 100%);
+  background-image: url('{{ site.baseurl }}assets/img/header_bg.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   color: #101828;
 }
 header.masthead .container {


### PR DESCRIPTION
## Summary
- restore the masthead background image and ensure it scales appropriately
- remove the opaque gradient background that obscured the image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d000702abc832e8bd478ef74bf1107