### PR TITLE
feat(hero): apply brand slogans with The Youngest Script accent (EN/TR)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2621,3 +2621,37 @@ h1, h2, h3, h4, h5 {
 .breadcrumb li:last-child::after {
   content: "";
 }
+
+/* ---- Masthead slogan tipografisi (minimal) ---- */
+
+/* 1) The Youngest Script: repo'da mevcut dosya: assets/fonts/the-youngest-script.ttf */
+@font-face {
+  font-family: "TheYoungestScript";
+  src: url("{{ site.baseurl }}assets/fonts/the-youngest-script.ttf") format("truetype");
+  font-display: swap;
+}
+
+/* 2) Başlık gövde fontu = Arial; yalnızca masthead başlığını hedefle */
+.masthead .hero-title {
+  font-family: Arial, "Helvetica Neue", Helvetica, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  color: #ffffff;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+  font-weight: 800;                 /* script olmayan kelimeler için ağırlık */
+  font-size: clamp(28px, 6vw, 64px);
+  text-wrap: balance;
+  text-shadow: 0 1px 2px rgba(0,0,0,.35); /* okunabilirlik */
+  text-align: center;               /* mobil için güvenli varsayılan */
+}
+
+/* 3) Script ile vurgulanan tek kelime */
+.masthead .hero-title .hero-script {
+  font-family: "TheYoungestScript", cursive;
+  font-weight: 400;
+  letter-spacing: 0;
+  display: inline-block;
+  transform: translateY(0.02em);    /* temel hizasını yumuşatır */
+  font-size: 1.05em;                /* çok hafif büyütme */
+  text-shadow: 0 1px 2px rgba(0,0,0,.35);
+}

--- a/index.html
+++ b/index.html
@@ -69,7 +69,9 @@
 <!-- Masthead -->
 <header class="masthead">
     <div class="container">
-        <h1 class="masthead-title">Rise for a Cleaner Planet</h1>
+        <h1 class="masthead-title hero-title">
+          <span>Rise For a</span> <span class="hero-script">Cleaner</span> <span>Planet</span>
+        </h1>
         <p class="masthead-tagline">Stories, updates, and ideas from the GreenAiriva team on making cleaner urban air a reality.</p>
     </div>
 </header>

--- a/tr/index.html
+++ b/tr/index.html
@@ -68,7 +68,9 @@
 <!-- Masthead -->
 <header class="masthead">
     <div class="container">
-        <h1 class="masthead-title">Daha Temiz Bir Dünya İçin Birlikte</h1>
+        <h1 class="masthead-title hero-title">
+          <span>Daha</span> <span class="hero-script">Temiz</span> <span>Bir Dünya</span>
+        </h1>
         <p class="masthead-tagline">Şehir havasını dönüştürmeye dair hikayeler, gelişmeler ve GreenAiriva ekibinden içgörüler.</p>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- split the English and Turkish masthead slogans into spans so the key word can be styled with the accent font
- introduce hero-specific typography rules that pair Arial body text with The Youngest Script for the highlighted word

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d01e1d5588832ea5f9fd0b4ac762c7